### PR TITLE
Fix message list padding to prevent overlap with status bar.

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -423,7 +423,9 @@ const createStyles = (theme: Theme) =>
       fontWeight: theme.typography.fontWeight.semibold,
     },
     messageList: {
-      paddingVertical: theme.spacing.sm,
+      paddingTop: 55,
+      paddingBottom: theme.spacing.sm,
+      paddingHorizontal: theme.spacing.sm,
     },
     emptyContainer: {
       flex: 1,


### PR DESCRIPTION
Added top padding to the message list to ensure messages don't appear behind the floating "Health OK" status bar and settings button.

Changes:
- Add paddingTop: 55 to messageList to push content below status bar
- Add paddingHorizontal for better horizontal spacing
- Split paddingVertical into separate top and bottom padding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated spacing and padding in the chat message list for refined layout positioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->