### PR TITLE
Add react-native-worklets dependency to fix iOS build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-native-reanimated": "~4.1.6",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "^4.16.0",
-    "react-native-webview": "^13.16.0"
+    "react-native-webview": "^13.16.0",
+    "react-native-worklets": "^0.7.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-native-webview:
         specifier: ^13.16.0
         version: 13.16.0(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-worklets:
+        specifier: ^0.7.2
+        version: 0.7.2(@babel/core@7.28.6)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.2


### PR DESCRIPTION
Fixes missing peer dependency error for react-native-reanimated.