### PR TITLE
Fix message list padding to prevent messages from hiding behind header.

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -462,7 +462,7 @@ const createStyles = (theme: Theme) =>
       fontWeight: theme.typography.fontWeight.semibold,
     },
     messageList: {
-      paddingTop: 55,
+      paddingTop: 110,
       paddingBottom: 60, // Room for input
       paddingHorizontal: theme.spacing.sm,
     },


### PR DESCRIPTION
Increase top padding from 55 to 110 to account for status bar and settings button height, ensuring first messages are fully visible.