### PR TITLE
Add App Store submission to iOS production workflow.

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -49,3 +49,6 @@ jobs:
 
       - name: Build iOS app
         run: eas build --platform ios --profile production --non-interactive
+
+      - name: Submit to App Store
+        run: eas submit --platform ios


### PR DESCRIPTION
Add eas submit step after build to automatically submit the iOS app to the App Store when the production build completes.