### PR TITLE
Fix iOS build submission by using unique build numbers

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -47,5 +47,10 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
+      - name: Set iOS build number
+        run: |
+          BUILD_NUMBER="${{ github.run_number }}"
+          npx json -I -f app.json -e "this.expo.ios.buildNumber='${BUILD_NUMBER:-1}'"
+
       - name: Build iOS app
         run: eas build --platform ios --profile production --non-interactive --auto-submit

--- a/app.json
+++ b/app.json
@@ -15,6 +15,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "bot.lumiere.app",
+      "buildNumber": "1",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }


### PR DESCRIPTION
Set expo.ios.buildNumber dynamically from github.run_number in the CI workflow so each build gets a unique CFBundleVersion, preventing "already submitted" errors. Defaults to 1 for local builds.

https://claude.ai/code/session_0158kdkfgCoqjF84kaZj1C3P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build configuration to automatically assign build numbers from workflow runs, ensuring consistent versioning across releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->