### PR TITLE
Add favorites feature with Jotai persistence

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -68,6 +68,14 @@ function AppContent() {
           headerShown: false,
         }}
       />
+      <Stack.Screen
+        name="favorites"
+        options={{
+          presentation: 'modal',
+          animation: 'slide_from_bottom',
+          headerShown: false,
+        }}
+      />
     </Stack>
   )
 }

--- a/app/favorites.tsx
+++ b/app/favorites.tsx
@@ -1,0 +1,129 @@
+import { Ionicons } from '@expo/vector-icons'
+import { useAtom } from 'jotai'
+import React from 'react'
+import {
+  Alert,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+
+import { ScreenHeader } from '../src/components/ui'
+import { FavoriteItem, favoritesAtom } from '../src/store'
+import { useTheme } from '../src/theme'
+
+export default function FavoritesScreen() {
+  const { theme } = useTheme()
+  const [favorites, setFavorites] = useAtom(favoritesAtom)
+
+  const handleRemove = (id: string) => {
+    Alert.alert('Remove Favorite', 'Are you sure you want to remove this from favorites?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Remove',
+        style: 'destructive',
+        onPress: () => setFavorites(favorites.filter((f) => f.id !== id)),
+      },
+    ])
+  }
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    scrollContent: {
+      padding: theme.spacing.lg,
+    },
+    emptyContainer: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: theme.spacing.xxxl,
+    },
+    emptyText: {
+      fontSize: theme.typography.fontSize.base,
+      color: theme.colors.text.secondary,
+      marginTop: theme.spacing.md,
+    },
+    card: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.borderRadius.md,
+      padding: theme.spacing.lg,
+      marginBottom: theme.spacing.md,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+    },
+    cardHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: theme.spacing.sm,
+    },
+    senderBadge: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.spacing.xs,
+    },
+    senderText: {
+      fontSize: theme.typography.fontSize.sm,
+      fontWeight: theme.typography.fontWeight.semibold as '600',
+      color: theme.colors.primary,
+      textTransform: 'capitalize',
+    },
+    dateText: {
+      fontSize: theme.typography.fontSize.xs,
+      color: theme.colors.text.tertiary,
+    },
+    messageText: {
+      fontSize: theme.typography.fontSize.base,
+      lineHeight: theme.typography.fontSize.base * theme.typography.lineHeight.normal,
+      color: theme.colors.text.primary,
+    },
+    removeButton: {
+      padding: theme.spacing.xs,
+    },
+  })
+
+  const renderItem = (item: FavoriteItem) => (
+    <View key={item.id} style={styles.card}>
+      <View style={styles.cardHeader}>
+        <View style={styles.senderBadge}>
+          <Ionicons
+            name={item.sender === 'user' ? 'person-outline' : 'sparkles-outline'}
+            size={14}
+            color={theme.colors.primary}
+          />
+          <Text style={styles.senderText}>{item.sender}</Text>
+        </View>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: theme.spacing.sm }}>
+          <Text style={styles.dateText}>{new Date(item.savedAt).toLocaleDateString()}</Text>
+          <TouchableOpacity style={styles.removeButton} onPress={() => handleRemove(item.id)}>
+            <Ionicons name="trash-outline" size={16} color={theme.colors.status.error} />
+          </TouchableOpacity>
+        </View>
+      </View>
+      <Text style={styles.messageText} numberOfLines={10}>
+        {item.text}
+      </Text>
+    </View>
+  )
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScreenHeader title="Favorites" showBack />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        {favorites.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <Ionicons name="heart-outline" size={48} color={theme.colors.text.tertiary} />
+            <Text style={styles.emptyText}>No favorites yet</Text>
+          </View>
+        ) : (
+          [...favorites].reverse().map(renderItem)
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  )
+}

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -149,6 +149,10 @@ export default function SettingsScreen() {
           />
         </Section>
 
+        <Section title="Content">
+          <SettingRow label="Favorites" onPress={() => router.push('/favorites')} />
+        </Section>
+
         <Section title="Control">
           <SettingRow label="Overview" onPress={() => router.push('/overview')} />
           <SettingRow label="Cron Jobs" onPress={() => router.push('/scheduler')} />

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -66,3 +66,13 @@ export const messageQueueAtom = atom<string[]>([])
 
 // Trigger to clear messages and reload history (in-memory only)
 export const clearMessagesAtom = atom<number>(0)
+
+// Favorites
+export interface FavoriteItem {
+  id: string
+  text: string
+  sender: 'user' | 'agent'
+  savedAt: number
+}
+
+export const favoritesAtom = atomWithStorage<FavoriteItem[]>('favorites', [], storage)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,10 @@
-export type { ServerConfig, ServersDict, ServerSessions } from './atoms'
+export type { FavoriteItem, ServerConfig, ServersDict, ServerSessions } from './atoms'
 export {
   clearMessagesAtom,
   colorThemeAtom,
   currentServerIdAtom,
   currentSessionKeyAtom,
+  favoritesAtom,
   gatewayConnectedAtom,
   gatewayConnectingAtom,
   gatewayErrorAtom,


### PR DESCRIPTION
- Add heart icon next to copy icon on chat messages to save/unsave favorites
- Create FavoriteItem type and favoritesAtom persisted with AsyncStorage
- Add favorites screen showing saved messages with remove option
- Register favorites route in root layout navigation
- Add favorites entry in settings screen under new Content section

https://claude.ai/code/session_01FCVK9Bo3moov59UU4aHa1J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to favorite and unfavorite chat messages with a heart icon
  * Created a Favorites screen accessible from Settings to view all saved favorites
  * Added confirmation when removing favorites
  * Favorites persist locally for future access
  * Empty state displays when no favorites are saved

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->