### PR TITLE
Add image sending with + button before session menu

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -49,11 +49,13 @@ export function ChatInput({
       mediaTypes: ['images'],
       allowsMultipleSelection: true,
       quality: 0.8,
+      base64: true,
     })
 
     if (!result.canceled && result.assets.length > 0) {
       const newAttachments: MessageAttachment[] = result.assets.map((asset) => ({
         uri: asset.uri,
+        base64: asset.base64 || undefined,
         mimeType: asset.mimeType || 'image/jpeg',
         fileName: asset.fileName || undefined,
         width: asset.width,

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../../theme'
 
 export interface MessageAttachment {
   uri: string
+  base64?: string
   mimeType?: string
   fileName?: string
   width?: number

--- a/src/hooks/useMessageQueue.ts
+++ b/src/hooks/useMessageQueue.ts
@@ -13,7 +13,7 @@ interface Message {
 
 interface QueuedItem {
   text: string
-  media?: { path: string }[]
+  attachments?: { mimeType: string; content: string }[]
   skipUserMessage?: boolean
 }
 
@@ -21,7 +21,7 @@ interface UseMessageQueueProps {
   sendAgentRequest: (
     params: {
       message: string
-      media?: { path: string }[]
+      attachments?: { mimeType: string; content: string }[]
       idempotencyKey: string
       agentId: string
       sessionKey: string
@@ -50,7 +50,10 @@ export function useMessageQueue({
   const [isAgentResponding, setIsAgentResponding] = useState(false)
 
   const sendMessage = useCallback(
-    async (text: string, opts?: { media?: { path: string }[]; skipUserMessage?: boolean }) => {
+    async (
+      text: string,
+      opts?: { attachments?: { mimeType: string; content: string }[]; skipUserMessage?: boolean },
+    ) => {
       if (!opts?.skipUserMessage) {
         const userMessage: Message = {
           id: `msg-${Date.now()}`,
@@ -71,7 +74,7 @@ export function useMessageQueue({
         await sendAgentRequest(
           {
             message: text,
-            media: opts?.media,
+            attachments: opts?.attachments,
             idempotencyKey: `msg-${Date.now()}-${Math.random()}`,
             agentId,
             sessionKey: currentSessionKey,
@@ -111,10 +114,13 @@ export function useMessageQueue({
   )
 
   const handleSend = useCallback(
-    async (text: string, opts?: { media?: { path: string }[]; skipUserMessage?: boolean }) => {
+    async (
+      text: string,
+      opts?: { attachments?: { mimeType: string; content: string }[]; skipUserMessage?: boolean },
+    ) => {
       if (isAgentResponding) {
         setMessageQueue((prev) => [...prev, text])
-        setItemQueue((prev) => [...prev, { text, media: opts?.media }])
+        setItemQueue((prev) => [...prev, { text, attachments: opts?.attachments }])
       } else {
         await sendMessage(text, opts)
       }
@@ -130,7 +136,7 @@ export function useMessageQueue({
       setMessageQueue((prev) => prev.slice(1))
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setItemQueue((prev) => prev.slice(1))
-      sendMessage(nextMessage, { media: nextItem?.media })
+      sendMessage(nextMessage, { attachments: nextItem?.attachments })
     }
   }, [isAgentResponding, messageQueue, itemQueue, sendMessage, setMessageQueue])
 

--- a/src/services/molt/client.ts
+++ b/src/services/molt/client.ts
@@ -5,7 +5,6 @@ import {
   ConnectResponse,
   EventFrame,
   HealthStatus,
-  MediaUploadResponse,
   MoltConfig,
   RequestFrame,
   ResponseFrame,
@@ -249,40 +248,6 @@ export class MoltGatewayClient {
     } else {
       return await this.request('agent', params)
     }
-  }
-
-  private getHttpBaseUrl(): string {
-    // Derive HTTP URL from WebSocket URL: ws:// → http://, wss:// → https://
-    return this.config.url.replace(/^ws(s?):\/\//, 'http$1://')
-  }
-
-  async uploadMedia(
-    files: { uri: string; mimeType: string; name: string }[],
-  ): Promise<MediaUploadResponse> {
-    const baseUrl = this.getHttpBaseUrl()
-    const formData = new FormData()
-
-    for (const file of files) {
-      formData.append('file', {
-        uri: file.uri,
-        type: file.mimeType,
-        name: file.name,
-      } as unknown as Blob)
-    }
-
-    const response = await fetch(`${baseUrl}/api/media/upload`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.config.token}`,
-      },
-      body: formData,
-    })
-
-    if (!response.ok) {
-      throw new Error(`Media upload failed: ${response.status} ${response.statusText}`)
-    }
-
-    return (await response.json()) as MediaUploadResponse
   }
 
   isConnected(): boolean {

--- a/src/services/molt/types.ts
+++ b/src/services/molt/types.ts
@@ -139,22 +139,10 @@ export interface Attachment {
   mimeType?: string
 }
 
-// Media upload response from POST /api/media/upload
-export interface MediaUploadFile {
-  path: string
-  mime: string
-  name: string
-  size: number
-}
-
-export interface MediaUploadResponse {
-  files: MediaUploadFile[]
-}
-
 // Agent params
 export interface AgentParams {
   message: string
-  media?: { path: string }[]
+  attachments?: { mimeType: string; content: string }[]
   idempotencyKey: string
   agentId?: string
   sessionKey?: string

--- a/src/services/molt/useMoltGateway.ts
+++ b/src/services/molt/useMoltGateway.ts
@@ -8,7 +8,6 @@ import {
   EventFrame,
   GatewaySnapshot,
   HealthStatus,
-  MediaUploadResponse,
   MoltConfig,
   SendMessageParams,
 } from './types'
@@ -26,9 +25,6 @@ export interface UseMoltGatewayResult {
   refreshHealth: () => Promise<void>
   sendMessage: (params: SendMessageParams) => Promise<unknown>
   sendAgentRequest: (params: AgentParams, onEvent?: (event: AgentEvent) => void) => Promise<unknown>
-  uploadMedia: (
-    files: { uri: string; mimeType: string; name: string }[],
-  ) => Promise<MediaUploadResponse>
   getChatHistory: (sessionKey: string, limit?: number) => Promise<unknown>
   resetSession: (sessionKey: string) => Promise<unknown>
   listSessions: () => Promise<unknown>
@@ -154,16 +150,6 @@ export function useMoltGateway(config: MoltConfig): UseMoltGatewayResult {
     [client],
   )
 
-  const uploadMedia = useCallback(
-    async (files: { uri: string; mimeType: string; name: string }[]) => {
-      if (!client) {
-        throw new Error('Client not connected')
-      }
-      return await client.uploadMedia(files)
-    },
-    [client],
-  )
-
   const getChatHistory = useCallback(
     async (sessionKey: string, limit?: number) => {
       if (!client) {
@@ -276,7 +262,6 @@ export function useMoltGateway(config: MoltConfig): UseMoltGatewayResult {
     refreshHealth,
     sendMessage,
     sendAgentRequest,
-    uploadMedia,
     getChatHistory,
     resetSession,
     listSessions,


### PR DESCRIPTION
- Install expo-image-picker for image selection from library
- Add "+" button before the 3-dots menu in ChatInput for picking images
- Support multiple image selection with preview strip and remove capability
- Extend Message type with attachments (uri, mimeType, base64, dimensions)
- Render image attachments in ChatMessage bubbles
- Wire image data through ChatScreen to the message queue

https://claude.ai/code/session_01XRkQGn2tgAePwxdLhdv31v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image attachment in chat: pick one or more images, preview thumbnails with remove option, and send attachments with messages.
  * Attachments render above message text; message text displays only if present.
  * Send button is enabled when text or attachments exist; media are uploaded automatically with fallback to text-only if upload fails.

* **Chores**
  * Added image picker dependency for media selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->