### PR TITLE
Add Face ID lock setting for app launch and resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "expo-clipboard": "~8.0.8",
         "expo-constants": "^18.0.13",
         "expo-linking": "^8.0.11",
+        "expo-local-authentication": "^17.0.8",
         "expo-router": "^6.0.22",
         "expo-secure-store": "^15.0.8",
         "expo-status-bar": "~3.0.9",
@@ -5304,7 +5305,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -8244,7 +8245,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -9882,6 +9883,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-local-authentication": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-17.0.8.tgz",
+      "integrity": "sha512-Q5fXHhu6w3pVPlFCibU72SYIAN+9wX7QpFn9h49IUqs0Equ44QgswtGrxeh7fdnDqJrrYGPet5iBzjnE70uolA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-manifests": {
@@ -16664,19 +16677,6 @@
         "ws": "^7"
       }
     },
-    "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
@@ -17865,13 +17865,6 @@
       "engines": {
         "node": ">=11.0.0"
       }
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "expo-clipboard": "~8.0.8",
     "expo-constants": "^18.0.13",
     "expo-linking": "^8.0.11",
+    "expo-local-authentication": "^17.0.8",
     "expo-router": "^6.0.22",
     "expo-secure-store": "^15.0.8",
     "expo-status-bar": "~3.0.9",

--- a/src/components/BiometricLockScreen.tsx
+++ b/src/components/BiometricLockScreen.tsx
@@ -1,0 +1,111 @@
+import * as LocalAuthentication from 'expo-local-authentication'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { AppState, AppStateStatus, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+
+import { useTheme } from '../theme'
+
+interface BiometricLockScreenProps {
+  onUnlock: () => void
+}
+
+export function BiometricLockScreen({ onUnlock }: BiometricLockScreenProps) {
+  const { theme } = useTheme()
+  const [error, setError] = useState<string | null>(null)
+  const appState = useRef(AppState.currentState)
+
+  const authenticate = useCallback(async () => {
+    setError(null)
+    const result = await LocalAuthentication.authenticateAsync({
+      promptMessage: 'Unlock Lumiere',
+      disableDeviceFallback: false,
+    })
+    if (result.success) {
+      onUnlock()
+    } else if (result.error !== 'user_cancel' && result.error !== 'system_cancel') {
+      setError('Authentication failed. Tap to try again.')
+    }
+  }, [onUnlock])
+
+  useEffect(() => {
+    let mounted = true
+    const doInitialAuth = async () => {
+      if (!mounted) return
+      const result = await LocalAuthentication.authenticateAsync({
+        promptMessage: 'Unlock Lumiere',
+        disableDeviceFallback: false,
+      })
+      if (!mounted) return
+      if (result.success) {
+        onUnlock()
+      } else if (result.error !== 'user_cancel' && result.error !== 'system_cancel') {
+        setError('Authentication failed. Tap to try again.')
+      }
+    }
+    doInitialAuth()
+    return () => {
+      mounted = false
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    const handleAppState = (nextState: AppStateStatus) => {
+      if (nextState === 'active' && appState.current !== 'active') {
+        authenticate()
+      }
+      appState.current = nextState
+    }
+    const subscription = AppState.addEventListener('change', handleAppState)
+    return () => subscription.remove()
+  }, [authenticate])
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: theme.spacing.xl,
+    },
+    title: {
+      fontSize: theme.typography.fontSize.xl,
+      fontWeight: theme.typography.fontWeight.bold as '700',
+      color: theme.colors.text.primary,
+      marginBottom: theme.spacing.md,
+    },
+    subtitle: {
+      fontSize: theme.typography.fontSize.base,
+      color: theme.colors.text.secondary,
+      textAlign: 'center',
+      marginBottom: theme.spacing.xl,
+    },
+    error: {
+      fontSize: theme.typography.fontSize.sm,
+      color: theme.colors.text.secondary,
+      textAlign: 'center',
+      marginTop: theme.spacing.md,
+    },
+    retryButton: {
+      paddingVertical: theme.spacing.md,
+      paddingHorizontal: theme.spacing.xl,
+      borderRadius: 8,
+      backgroundColor: theme.colors.primary,
+    },
+    retryText: {
+      fontSize: theme.typography.fontSize.base,
+      fontWeight: theme.typography.fontWeight.semiBold as '600',
+      color: '#ffffff',
+    },
+  })
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Locked</Text>
+      <Text style={styles.subtitle}>Authenticate to unlock Lumiere</Text>
+      <TouchableOpacity style={styles.retryButton} onPress={authenticate} activeOpacity={0.7}>
+        <Text style={styles.retryText}>Unlock</Text>
+      </TouchableOpacity>
+      {error && <Text style={styles.error}>{error}</Text>}
+    </View>
+  )
+}

--- a/src/components/ui/SettingRow.tsx
+++ b/src/components/ui/SettingRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native'
 
 import { useTheme } from '../../theme'
 
@@ -7,13 +7,18 @@ export interface SettingRowProps {
   label: string
   value?: string
   onPress?: () => void
+  switchValue?: boolean
+  onSwitchChange?: (value: boolean) => void
 }
 
-export function SettingRow({ label, value, onPress }: SettingRowProps) {
+export function SettingRow({ label, value, onPress, switchValue, onSwitchChange }: SettingRowProps) {
   const { theme } = useTheme()
 
   const styles = StyleSheet.create({
     row: {
+      flexDirection: switchValue !== undefined ? 'row' : 'column',
+      alignItems: switchValue !== undefined ? 'center' : 'flex-start',
+      justifyContent: switchValue !== undefined ? 'space-between' : 'flex-start',
       paddingVertical: theme.spacing.lg,
       borderBottomWidth: 1,
       borderBottomColor: theme.colors.border,
@@ -33,6 +38,9 @@ export function SettingRow({ label, value, onPress }: SettingRowProps) {
     <View style={styles.row}>
       <Text style={styles.label}>{label}</Text>
       {value && <Text style={styles.value}>{value}</Text>}
+      {switchValue !== undefined && (
+        <Switch value={switchValue} onValueChange={onSwitchChange} />
+      )}
     </View>
   )
 

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -76,3 +76,10 @@ export interface FavoriteItem {
 }
 
 export const favoritesAtom = atomWithStorage<FavoriteItem[]>('favorites', [], storage)
+
+// Biometric lock setting (off by default)
+export const biometricLockEnabledAtom = atomWithStorage<boolean>(
+  'biometricLockEnabled',
+  false,
+  storage,
+)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 export type { FavoriteItem, ServerConfig, ServersDict, ServerSessions } from './atoms'
 export {
+  biometricLockEnabledAtom,
   clearMessagesAtom,
   colorThemeAtom,
   currentServerIdAtom,


### PR DESCRIPTION
Adds a "Require Face ID" toggle in Settings > Security that gates
app access behind biometric authentication. When enabled, the app
shows a lock screen on launch and whenever it returns from background.
Off by default.

- Install expo-local-authentication for biometric APIs
- Add biometricLockEnabledAtom persisted via AsyncStorage
- Extend SettingRow with optional Switch toggle support
- Create BiometricLockScreen component shown when locked
- Integrate lock state management in root layout via AppState

https://claude.ai/code/session_018GyFkGAW9yZzaaQs45w1hW