### PR TITLE
Clear chat messages immediately when switching sessions

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -121,6 +121,10 @@ export function ChatScreen({ gatewayUrl, gatewayToken }: ChatScreenProps) {
 
   // Load chat history on mount
   const loadChatHistory = useCallback(async () => {
+    // Clear old messages immediately so stale content doesn't flash on screen
+    setMessages([])
+    setCurrentAgentMessage('')
+    hasScrolledOnLoadRef.current = false
     setIsLoadingHistory(true)
     try {
       const history = await getChatHistory(currentSessionKey, 100)


### PR DESCRIPTION
When changing sessions, the old session's messages were briefly
visible while the new history loaded. Now messages are cleared
at the start of loadChatHistory so stale content doesn't flash.

https://claude.ai/code/session_01CWmxmsfjez2DfftiWBzDDm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where outdated messages could appear when loading chat history. The chat now properly clears and resets its state before fetching previous conversations, ensuring a clean display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->