### PR TITLE
Add missing gateway and client atoms used by settings screen

### DIFF
--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -77,6 +77,11 @@ export interface FavoriteItem {
 
 export const favoritesAtom = atomWithStorage<FavoriteItem[]>('favorites', [], storage)
 
+// Gateway settings (persisted for logout reset)
+export const gatewayUrlAtom = atomWithStorage<string>('gatewayUrl', '', storage)
+export const gatewayTokenAtom = atomWithStorage<string>('gatewayToken', '', storage)
+export const clientIdAtom = atomWithStorage<string>('clientId', 'lumiere-mobile', storage)
+
 // Biometric lock setting (off by default)
 export const biometricLockEnabledAtom = atomWithStorage<boolean>(
   'biometricLockEnabled',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ export type { FavoriteItem, ServerConfig, ServersDict, ServerSessions } from './
 export {
   biometricLockEnabledAtom,
   clearMessagesAtom,
+  clientIdAtom,
   colorThemeAtom,
   currentServerIdAtom,
   currentSessionKeyAtom,
@@ -9,6 +10,8 @@ export {
   gatewayConnectedAtom,
   gatewayConnectingAtom,
   gatewayErrorAtom,
+  gatewayTokenAtom,
+  gatewayUrlAtom,
   messageQueueAtom,
   onboardingCompletedAtom,
   serversAtom,


### PR DESCRIPTION
The settings screen imported clientIdAtom, gatewayTokenAtom, and
gatewayUrlAtom from the store, but these atoms were never defined
or exported, causing a build error that broke the entire settings
page including Face ID and security settings.

https://claude.ai/code/session_017RXt7Q3mnrP9MBLW5rQj4Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for persisting gateway configuration settings including gateway URL, authentication credentials, and client identifier across app sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->