### PR TITLE
Fix white flash during Face ID unlock in dark mode

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
       "image": "./assets/splash-icon.png",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,16 +1,17 @@
 import { Stack } from 'expo-router'
 import { useAtom } from 'jotai'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AppState, AppStateStatus } from 'react-native'
+import { AppState, AppStateStatus, View } from 'react-native'
 import { KeyboardProvider } from 'react-native-keyboard-controller'
 
 import { BiometricLockScreen } from '../src/components/BiometricLockScreen'
 import { useDeepLinking } from '../src/hooks/useDeepLinking'
 import { OnboardingScreen } from '../src/screens/OnboardingScreen'
 import { biometricLockEnabledAtom, onboardingCompletedAtom } from '../src/store'
-import { ThemeProvider } from '../src/theme'
+import { ThemeProvider, useTheme } from '../src/theme'
 
 function AppContent() {
+  const { theme } = useTheme()
   const [onboardingCompleted] = useAtom(onboardingCompletedAtom)
   const [biometricLockEnabled] = useAtom(biometricLockEnabledAtom)
   const [isLocked, setIsLocked] = useState(() => biometricLockEnabled)
@@ -37,18 +38,29 @@ function AppContent() {
     return () => subscription.remove()
   }, [biometricLockEnabled])
 
+  const backgroundStyle = { flex: 1, backgroundColor: theme.colors.background }
+
   if (!onboardingCompleted) {
-    return <OnboardingScreen />
+    return (
+      <View style={backgroundStyle}>
+        <OnboardingScreen />
+      </View>
+    )
   }
 
   if (biometricLockEnabled && isLocked) {
-    return <BiometricLockScreen onUnlock={handleUnlock} />
+    return (
+      <View style={backgroundStyle}>
+        <BiometricLockScreen onUnlock={handleUnlock} />
+      </View>
+    )
   }
 
   return (
     <Stack
       screenOptions={{
         headerShown: false,
+        contentStyle: { backgroundColor: theme.colors.background },
       }}
     >
       <Stack.Screen name="index" options={{ headerShown: false }} />


### PR DESCRIPTION
Three changes to eliminate the brief white flash visible when the app
transitions between the biometric lock screen and the main app in dark mode:

- Change userInterfaceStyle from "light" to "automatic" in app.json so the
  native window background respects the system dark mode setting
- Wrap BiometricLockScreen and OnboardingScreen in a View with the theme
  background color to prevent the native white background from peeking
  through during transitions
- Add contentStyle with theme background to the Stack navigator so screen
  transitions don't flash white

https://claude.ai/code/session_01Tdgmp5NXX4q7yWcTTJiiwp