### PR TITLE
Add +not-found route to fix deep link routing for triggers

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,0 +1,11 @@
+import { Redirect } from 'expo-router'
+
+/**
+ * Catch-all for routes not matched by Expo Router's file-based routing.
+ * This prevents deep links like lumiere://trigger/autotrigger/{slug} from
+ * showing a 404 screen. The useDeepLinking hook in _layout.tsx independently
+ * picks up the URL via Linking.getInitialURL() and handles it.
+ */
+export default function NotFound() {
+  return <Redirect href="/" />
+}


### PR DESCRIPTION
Expo Router intercepts deep links like lumiere://trigger/autotrigger/{slug}
and tries to match them against file-based routes. Since no matching route
exists, it shows a 404 instead of letting useDeepLinking handle the URL.

The +not-found.tsx catch-all redirects unmatched routes to home, allowing
the useDeepLinking hook to independently process trigger URLs via
Linking.getInitialURL().

https://claude.ai/code/session_01HMbgJgdAMQTkWQEwhGwto4