### PR TITLE
Remove echo server feature flag to always show echo servers

### DIFF
--- a/app/add-server.tsx
+++ b/app/add-server.tsx
@@ -30,8 +30,7 @@ export default function AddServerScreen() {
   const { flags } = useFeatureFlags()
 
   const providerOptions = ALL_PROVIDER_OPTIONS.filter(
-    (o) =>
-      (o.value !== 'ollama' || flags.ollamaProvider) && (o.value !== 'echo' || flags.echoProvider),
+    (o) => o.value !== 'ollama' || flags.ollamaProvider,
   )
 
   const [name, setName] = useState('')

--- a/app/edit-server.tsx
+++ b/app/edit-server.tsx
@@ -31,8 +31,7 @@ export default function EditServerScreen() {
   const { flags } = useFeatureFlags()
 
   const providerOptions = ALL_PROVIDER_OPTIONS.filter(
-    (o) =>
-      (o.value !== 'ollama' || flags.ollamaProvider) && (o.value !== 'echo' || flags.echoProvider),
+    (o) => o.value !== 'ollama' || flags.ollamaProvider,
   )
 
   const server = id ? servers[id] : null

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -203,11 +203,6 @@ export default function SettingsScreen() {
             switchValue={flags.ollamaProvider}
             onSwitchChange={(value) => setFlag('ollamaProvider', value)}
           />
-          <SettingRow
-            label="Echo Server"
-            switchValue={flags.echoProvider}
-            onSwitchChange={(value) => setFlag('echoProvider', value)}
-          />
         </Section>
 
         <Section title="Developer">

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -116,11 +116,10 @@ export const pendingTriggerMessageAtom = atom<string | null>(null)
 // Feature flags (persisted)
 export interface FeatureFlags {
   ollamaProvider: boolean
-  echoProvider: boolean
 }
 
 export const featureFlagsAtom = atomWithStorage<FeatureFlags>(
   'featureFlags',
-  { ollamaProvider: false, echoProvider: true },
+  { ollamaProvider: false },
   storage,
 )


### PR DESCRIPTION
The echo provider was gated behind a feature flag, which prevented
users with persisted storage from seeing it even after the default
was changed to true. Echo servers are now always available as a
provider option.

https://claude.ai/code/session_014AET8g1WMKPjTeudUXxLvT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Echo Server provider is now permanently enabled and always available when adding, editing, or managing servers without requiring separate feature flag management
  * Removed the Echo Server feature flag toggle from the Feature Flags section in settings
  * Simplified the underlying provider filtering logic to streamline configuration management while maintaining support for Ollama provider feature control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->