### PR TITLE
Fix UI not updating when switching servers

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,7 +11,7 @@ import { useTheme } from '../src/theme'
 export default function HomeScreen() {
   const { theme } = useTheme()
   const router = useRouter()
-  const { getProviderConfig } = useServers()
+  const { getProviderConfig, currentServerId } = useServers()
   const [config, setConfig] = useState<ProviderConfig | null>(null)
 
   useEffect(() => {
@@ -20,7 +20,7 @@ export default function HomeScreen() {
       setConfig(providerConfig)
     }
     loadConfig()
-  }, [getProviderConfig])
+  }, [getProviderConfig, currentServerId])
 
   if (!config) {
     return (
@@ -44,5 +44,5 @@ export default function HomeScreen() {
     )
   }
 
-  return <ChatScreen providerConfig={config} />
+  return <ChatScreen key={currentServerId} providerConfig={config} />
 }

--- a/app/overview.tsx
+++ b/app/overview.tsx
@@ -18,7 +18,7 @@ import { useTheme } from '../src/theme'
 export default function OverviewScreen() {
   const { theme } = useTheme()
   const router = useRouter()
-  const { getProviderConfig } = useServers()
+  const { getProviderConfig, currentServerId } = useServers()
   const [config, setConfig] = useState<{ url: string; token: string } | null>(null)
 
   const [password, setPassword] = useState('')
@@ -41,7 +41,7 @@ export default function OverviewScreen() {
       setConfig(providerConfig)
     }
     loadConfig()
-  }, [getProviderConfig])
+  }, [getProviderConfig, currentServerId])
 
   useEffect(() => {
     if (config) {

--- a/app/scheduler.tsx
+++ b/app/scheduler.tsx
@@ -40,7 +40,7 @@ interface CronJob {
 export default function SchedulerScreen() {
   const { theme } = useTheme()
   const router = useRouter()
-  const { getProviderConfig } = useServers()
+  const { getProviderConfig, currentServerId } = useServers()
   const [config, setConfig] = useState<{ url: string; token: string } | null>(null)
 
   const [schedulerStatus, setSchedulerStatus] = useState<SchedulerStatus | null>(null)
@@ -52,7 +52,7 @@ export default function SchedulerScreen() {
       setConfig(providerConfig)
     }
     loadConfig()
-  }, [getProviderConfig])
+  }, [getProviderConfig, currentServerId])
 
   const {
     connected,

--- a/app/sessions.tsx
+++ b/app/sessions.tsx
@@ -19,7 +19,7 @@ interface Session {
 export default function SessionsScreen() {
   const { theme } = useTheme()
   const router = useRouter()
-  const { getProviderConfig } = useServers()
+  const { getProviderConfig, currentServerId } = useServers()
   const [currentSessionKey, setCurrentSessionKey] = useAtom(currentSessionKeyAtom)
   const [, setClearMessagesTrigger] = useAtom(clearMessagesAtom)
   const [sessionAliases] = useAtom(sessionAliasesAtom)
@@ -34,7 +34,7 @@ export default function SessionsScreen() {
       setConfig(providerConfig)
     }
     loadConfig()
-  }, [getProviderConfig])
+  }, [getProviderConfig, currentServerId])
 
   const { connected, connect, disconnect, listSessions, resetSession } = useMoltGateway({
     url: config?.url || '',


### PR DESCRIPTION
The config-loading useEffect in multiple screens depended solely on the
getProviderConfig callback reference to detect server changes. This
indirect dependency chain (atom → useMemo → useCallback → useEffect)
was fragile and could miss updates. Adding currentServerId as an
explicit primitive dependency guarantees the effect fires on every
server switch.

Additionally, ChatScreen now receives key={currentServerId} so it fully
remounts when the server changes, clearing stale messages and
reconnecting to the new server.

Affected screens: index, overview, sessions, scheduler.

https://claude.ai/code/session_01VjWB9PPkut4r5nDvMvUBux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration data now refreshes correctly when switching between servers, ensuring the active server's settings are properly applied across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->