### PR TITLE
Add provider picker to onboarding setup and rename Molt to OpenClaw

### DIFF
--- a/app/add-server.tsx
+++ b/app/add-server.tsx
@@ -17,7 +17,7 @@ import { ProviderType } from '../src/services/providers'
 import { useTheme } from '../src/theme'
 
 const ALL_PROVIDER_OPTIONS: { value: ProviderType; label: string }[] = [
-  { value: 'molt', label: 'Molt Gateway' },
+  { value: 'molt', label: 'OpenClaw' },
   { value: 'ollama', label: 'Ollama' },
   { value: 'echo', label: 'Echo Server' },
 ]
@@ -42,7 +42,7 @@ export default function AddServerScreen() {
     }
 
     if (providerType === 'molt' && !token.trim()) {
-      Alert.alert('Error', 'Token is required for Molt Gateway')
+      Alert.alert('Error', 'Token is required for OpenClaw')
       return
     }
 

--- a/app/edit-server.tsx
+++ b/app/edit-server.tsx
@@ -17,7 +17,7 @@ import { ProviderType } from '../src/services/providers'
 import { useTheme } from '../src/theme'
 
 const ALL_PROVIDER_OPTIONS: { value: ProviderType; label: string }[] = [
-  { value: 'molt', label: 'Molt Gateway' },
+  { value: 'molt', label: 'OpenClaw' },
   { value: 'ollama', label: 'Ollama' },
   { value: 'echo', label: 'Echo Server' },
 ]

--- a/app/servers.tsx
+++ b/app/servers.tsx
@@ -9,7 +9,7 @@ import { ProviderType } from '../src/services/providers'
 import { useTheme } from '../src/theme'
 
 const PROVIDER_OPTIONS: { value: ProviderType; label: string }[] = [
-  { value: 'molt', label: 'Molt Gateway' },
+  { value: 'molt', label: 'OpenClaw' },
   { value: 'ollama', label: 'Ollama' },
   { value: 'echo', label: 'Echo Server' },
 ]

--- a/src/screens/OnboardingFlow.tsx
+++ b/src/screens/OnboardingFlow.tsx
@@ -27,7 +27,7 @@ const INTRO_STEPS = [
   {
     title: 'Highly configurable for custom needs',
     description:
-      'Connect to Molt Gateway, Ollama, or Echo providers. Customize themes, set up deep link triggers, and tailor the experience to fit your workflow.',
+      'Connect to OpenClaw, Ollama, or Echo providers. Customize themes, set up deep link triggers, and tailor the experience to fit your workflow.',
     illustration: ConfigIllustration,
   },
 ]

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -126,7 +126,7 @@ export function OnboardingScreen() {
               autoCapitalize="none"
               autoCorrect={false}
               keyboardType="url"
-              hint="The URL of your Molt Gateway server"
+              hint="The URL of your OpenClaw server"
             />
 
             <TextInput

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -13,8 +13,14 @@ import {
 import { Button, Text, TextInput } from '../components/ui'
 import { DEFAULT_SESSION_KEY } from '../constants'
 import { useServers } from '../hooks/useServers'
+import { ProviderType } from '../services/providers'
 import { currentSessionKeyAtom, onboardingCompletedAtom, serverSessionsAtom } from '../store'
 import { useTheme } from '../theme'
+
+const PROVIDER_OPTIONS: { value: ProviderType; label: string }[] = [
+  { value: 'molt', label: 'OpenClaw' },
+  { value: 'ollama', label: 'Ollama' },
+]
 
 export function SetupScreen() {
   const { theme } = useTheme()
@@ -23,10 +29,12 @@ export function SetupScreen() {
   const [, setServerSessions] = useAtom(serverSessionsAtom)
   const [, setOnboardingCompleted] = useAtom(onboardingCompletedAtom)
 
+  const [providerType, setProviderType] = useState<ProviderType>('molt')
   const [localUrl, setLocalUrl] = useState('')
   const [localToken, setLocalToken] = useState('')
   const [localClientId, setLocalClientId] = useState('lumiere-mobile')
   const [localSessionKey, setLocalSessionKey] = useState(DEFAULT_SESSION_KEY)
+  const [localModel, setLocalModel] = useState('')
   const [showAdvanced, setShowAdvanced] = useState(false)
 
   const styles = StyleSheet.create({
@@ -40,6 +48,32 @@ export function SetupScreen() {
     },
     form: {
       marginBottom: theme.spacing.xxl,
+    },
+    providerPicker: {
+      flexDirection: 'row',
+      gap: theme.spacing.sm,
+      marginBottom: theme.spacing.lg,
+    },
+    providerOption: {
+      flex: 1,
+      paddingVertical: theme.spacing.sm + 2,
+      paddingHorizontal: theme.spacing.md,
+      borderRadius: theme.borderRadius.sm,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      alignItems: 'center',
+    },
+    providerOptionActive: {
+      borderColor: theme.colors.primary,
+      backgroundColor: theme.isDark ? 'rgba(99,102,241,0.15)' : 'rgba(99,102,241,0.08)',
+    },
+    providerOptionText: {
+      fontSize: 14,
+      color: theme.colors.text.secondary,
+    },
+    providerOptionTextActive: {
+      color: theme.colors.primary,
+      fontWeight: '600',
     },
     advancedToggle: {
       flexDirection: 'row',
@@ -56,7 +90,7 @@ export function SetupScreen() {
   })
 
   const handleComplete = async () => {
-    if (localUrl.trim() && localToken.trim()) {
+    if (providerType === 'molt' && localUrl.trim() && localToken.trim()) {
       const serverId = await addServer(
         {
           name: 'My Server',
@@ -68,6 +102,25 @@ export function SetupScreen() {
       )
 
       const sessionKey = localSessionKey.trim()
+      setCurrentSessionKey(sessionKey)
+      setServerSessions((prev) => ({
+        ...prev,
+        [serverId]: sessionKey,
+      }))
+
+      setOnboardingCompleted(true)
+    } else if (providerType === 'ollama' && localUrl.trim()) {
+      const serverId = await addServer(
+        {
+          name: 'My Ollama',
+          url: localUrl.trim(),
+          providerType: 'ollama',
+          model: localModel.trim() || undefined,
+        },
+        'ollama-no-token',
+      )
+
+      const sessionKey = DEFAULT_SESSION_KEY
       setCurrentSessionKey(sessionKey)
       setServerSessions((prev) => ({
         ...prev,
@@ -98,7 +151,10 @@ export function SetupScreen() {
     setOnboardingCompleted(true)
   }
 
-  const isValid = localUrl.trim().length > 0 && localToken.trim().length > 0
+  const isValid =
+    providerType === 'molt'
+      ? localUrl.trim().length > 0 && localToken.trim().length > 0
+      : localUrl.trim().length > 0
 
   return (
     <KeyboardAvoidingView
@@ -110,67 +166,115 @@ export function SetupScreen() {
           Setup your server
         </Text>
         <Text variant="body" color="secondary" style={{ marginBottom: theme.spacing.xxl }}>
-          Connect to your Molt Gateway to start chatting with your agents.
+          Choose a provider and connect to start chatting with your agents.
         </Text>
 
         <View style={styles.form}>
+          <View style={styles.providerPicker}>
+            {PROVIDER_OPTIONS.map((option) => (
+              <TouchableOpacity
+                key={option.value}
+                style={[
+                  styles.providerOption,
+                  providerType === option.value && styles.providerOptionActive,
+                ]}
+                onPress={() => setProviderType(option.value)}
+              >
+                <Text
+                  style={[
+                    styles.providerOptionText,
+                    providerType === option.value && styles.providerOptionTextActive,
+                  ]}
+                >
+                  {option.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
           <TextInput
-            label="Gateway URL"
+            label="URL"
             value={localUrl}
             onChangeText={setLocalUrl}
-            placeholder="https://your-gateway.example.com"
+            placeholder={
+              providerType === 'ollama'
+                ? 'http://localhost:11434'
+                : 'https://your-gateway.example.com'
+            }
             autoCapitalize="none"
             autoCorrect={false}
             keyboardType="url"
-            hint="The URL of your Molt Gateway server"
+            hint={
+              providerType === 'ollama'
+                ? 'The URL of your Ollama server'
+                : 'The URL of your OpenClaw server'
+            }
           />
 
-          <TextInput
-            label="Gateway Token"
-            value={localToken}
-            onChangeText={setLocalToken}
-            placeholder="Your authentication token"
-            autoCapitalize="none"
-            autoCorrect={false}
-            secureTextEntry
-            hint="Your authentication token for the gateway"
-          />
-
-          <TouchableOpacity
-            style={styles.advancedToggle}
-            onPress={() => setShowAdvanced(!showAdvanced)}
-          >
-            <Text variant="label" color="secondary">
-              Advanced
-            </Text>
-            <Ionicons
-              name={showAdvanced ? 'chevron-up' : 'chevron-down'}
-              size={20}
-              color={theme.colors.text.secondary}
+          {providerType === 'molt' && (
+            <TextInput
+              label="Token"
+              value={localToken}
+              onChangeText={setLocalToken}
+              placeholder="Your authentication token"
+              autoCapitalize="none"
+              autoCorrect={false}
+              secureTextEntry
+              hint="Your authentication token for the gateway"
             />
-          </TouchableOpacity>
+          )}
 
-          {showAdvanced && (
+          {providerType === 'ollama' && (
+            <TextInput
+              label="Model"
+              value={localModel}
+              onChangeText={setLocalModel}
+              placeholder="llama3.2"
+              autoCapitalize="none"
+              autoCorrect={false}
+              hint="Ollama model to use (default: llama3.2)"
+            />
+          )}
+
+          {providerType === 'molt' && (
             <>
-              <TextInput
-                label="Client ID"
-                value={localClientId}
-                onChangeText={setLocalClientId}
-                placeholder="lumiere-mobile"
-                autoCapitalize="none"
-                autoCorrect={false}
-                hint="Identifier for this device (default: lumiere-mobile)"
-              />
+              <TouchableOpacity
+                style={styles.advancedToggle}
+                onPress={() => setShowAdvanced(!showAdvanced)}
+              >
+                <Text variant="label" color="secondary">
+                  Advanced
+                </Text>
+                <Ionicons
+                  name={showAdvanced ? 'chevron-up' : 'chevron-down'}
+                  size={20}
+                  color={theme.colors.text.secondary}
+                />
+              </TouchableOpacity>
 
-              <TextInput
-                label="Default Session Key"
-                value={localSessionKey}
-                onChangeText={setLocalSessionKey}
-                placeholder={DEFAULT_SESSION_KEY}
-                autoCapitalize="none"
-                autoCorrect={false}
-                hint={`Session key for chat conversations (default: ${DEFAULT_SESSION_KEY})`}
-              />
+              {showAdvanced && (
+                <>
+                  <TextInput
+                    label="Client ID"
+                    value={localClientId}
+                    onChangeText={setLocalClientId}
+                    placeholder="lumiere-mobile"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    hint="Identifier for this device (default: lumiere-mobile)"
+                  />
+
+                  <TextInput
+                    label="Default Session Key"
+                    value={localSessionKey}
+                    onChangeText={setLocalSessionKey}
+                    placeholder={DEFAULT_SESSION_KEY}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    hint={`Session key for chat conversations (default: ${DEFAULT_SESSION_KEY})`}
+                  />
+                </>
+              )}
             </>
           )}
         </View>


### PR DESCRIPTION
Allow users to choose between OpenClaw and Ollama during onboarding setup, showing provider-specific fields for each. Rename all user-facing "Molt Gateway" labels to "OpenClaw" while preserving the internal type.