### PR TITLE
Make speech transcription module optional with graceful fallbacks

### DIFF
--- a/modules/speech-transcription/src/SpeechTranscriptionModule.ts
+++ b/modules/speech-transcription/src/SpeechTranscriptionModule.ts
@@ -1,5 +1,5 @@
 import type { EventSubscription } from 'expo-modules-core'
-import { requireNativeModule } from 'expo-modules-core'
+import { requireOptionalNativeModule } from 'expo-modules-core'
 
 interface TranscriptionEvent {
   text: string
@@ -23,34 +23,44 @@ interface SpeechTranscriptionNativeModule {
   addListener(eventName: 'onError', listener: (event: ErrorEvent) => void): EventSubscription
 }
 
-const nativeModule = requireNativeModule<SpeechTranscriptionNativeModule>('SpeechTranscription')
+const nativeModule =
+  requireOptionalNativeModule<SpeechTranscriptionNativeModule>('SpeechTranscription')
+
+const noopSubscription: EventSubscription = { remove: () => {} }
 
 export default {
   async isAvailable(): Promise<boolean> {
+    if (!nativeModule) return false
     return nativeModule.isAvailable()
   },
 
   async requestPermissions(): Promise<boolean> {
+    if (!nativeModule) return false
     return nativeModule.requestPermissions()
   },
 
   async startTranscription(): Promise<void> {
+    if (!nativeModule) return
     return nativeModule.startTranscription()
   },
 
   async stopTranscription(): Promise<string> {
+    if (!nativeModule) return ''
     return nativeModule.stopTranscription()
   },
 
   async cancelTranscription(): Promise<void> {
+    if (!nativeModule) return
     return nativeModule.cancelTranscription()
   },
 
   addTranscriptionListener(callback: (event: TranscriptionEvent) => void): EventSubscription {
+    if (!nativeModule) return noopSubscription
     return nativeModule.addListener('onTranscription', callback)
   },
 
   addErrorListener(callback: (event: ErrorEvent) => void): EventSubscription {
+    if (!nativeModule) return noopSubscription
     return nativeModule.addListener('onError', callback)
   },
 }


### PR DESCRIPTION
## Summary
This PR makes the Speech Transcription native module optional, allowing the app to function gracefully when the native module is unavailable (e.g., on unsupported platforms or when the module isn't linked).

## Key Changes
- Changed from `requireNativeModule` to `requireOptionalNativeModule` to allow the module to be undefined
- Added null checks in all public methods to handle cases where the native module is unavailable
- Implemented sensible fallback return values:
  - `isAvailable()` and `requestPermissions()` return `false`
  - `stopTranscription()` returns empty string
  - `startTranscription()` and `cancelTranscription()` return `undefined`
- Created a `noopSubscription` object for listener methods to return when the module is unavailable, preventing errors when callers try to remove subscriptions

## Implementation Details
- All methods now perform an early null check before attempting to call native module methods
- Event listeners return a no-op subscription that safely handles removal attempts without throwing errors
- This approach maintains API compatibility while preventing runtime crashes on platforms without native support

https://claude.ai/code/session_016oUv9W3ZuZUzSRfSt6WfY3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the speech transcription feature to gracefully handle scenarios where underlying native components are unavailable, preventing application crashes and ensuring continued functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->