### PR TITLE
Remove redundant build phase creation in iOS widget setup

### DIFF
--- a/plugins/withIOSWidget.js
+++ b/plugins/withIOSWidget.js
@@ -162,10 +162,8 @@ function withIOSWidget(config) {
       widgetBundleId,
     )
 
-    // Add build phases
-    xcodeProject.addBuildPhase([], 'PBXSourcesBuildPhase', 'Sources', target.uuid)
-
     // Add each Swift file to the sources build phase
+    // (addTarget already created the PBXSourcesBuildPhase, so we just add files to it)
     for (const file of swiftFiles) {
       xcodeProject.addSourceFile(
         `${WIDGET_TARGET_NAME}/${file}`,
@@ -174,9 +172,8 @@ function withIOSWidget(config) {
       )
     }
 
-    // Frameworks build phase
-    xcodeProject.addBuildPhase([], 'PBXFrameworksBuildPhase', 'Frameworks', target.uuid)
-
+    // Add frameworks to the widget target
+    // (addTarget already created the PBXFrameworksBuildPhase, so we just add frameworks to it)
     xcodeProject.addFramework('WidgetKit.framework', {
       target: target.uuid,
       link: true,


### PR DESCRIPTION
## Summary
Removed redundant `addBuildPhase()` calls in the iOS widget configuration since `addTarget()` already creates the necessary build phases automatically.

## Changes
- Removed explicit `PBXSourcesBuildPhase` creation - the Sources build phase is already created by `addTarget()`
- Removed explicit `PBXFrameworksBuildPhase` creation - the Frameworks build phase is already created by `addTarget()`
- Updated comments to clarify that build phases are pre-created and we're only adding files/frameworks to existing phases

## Details
The `addTarget()` method in xcode-build-phase already initializes both the Sources and Frameworks build phases for the new target. Creating them again with `addBuildPhase()` was redundant and could potentially cause issues. The subsequent calls to `addSourceFile()` and `addFramework()` correctly add items to these pre-existing phases.

https://claude.ai/code/session_011p1dGqBcdrJ4mCuahqE7Hr