### PR TITLE
Restrict Overview and Scheduler to OpenClaw servers only

### DIFF
--- a/app/overview.tsx
+++ b/app/overview.tsx
@@ -18,7 +18,7 @@ import { useTheme } from '../src/theme'
 export default function OverviewScreen() {
   const { theme } = useTheme()
   const router = useRouter()
-  const { getProviderConfig, currentServerId } = useServers()
+  const { getProviderConfig, currentServerId, currentServer } = useServers()
   const [config, setConfig] = useState<{ url: string; token: string } | null>(null)
 
   const [password, setPassword] = useState('')
@@ -216,6 +216,30 @@ export default function OverviewScreen() {
       marginBottom: theme.spacing.md,
     },
   })
+
+  if (currentServer?.providerType !== 'molt') {
+    return (
+      <SafeAreaView style={styles.container}>
+        <ScreenHeader title="Overview" showBack />
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: theme.spacing.xl,
+          }}
+        >
+          <Text variant="heading2" style={{ marginBottom: theme.spacing.md }}>
+            OpenClaw Only
+          </Text>
+          <Text color="secondary" center style={{ marginBottom: theme.spacing.xl }}>
+            Overview is only available for OpenClaw servers.
+          </Text>
+          <Button title="Go to Settings" onPress={() => router.push('/settings')} />
+        </View>
+      </SafeAreaView>
+    )
+  }
 
   if (!config) {
     return (

--- a/app/scheduler.tsx
+++ b/app/scheduler.tsx
@@ -40,7 +40,7 @@ interface CronJob {
 export default function SchedulerScreen() {
   const { theme } = useTheme()
   const router = useRouter()
-  const { getProviderConfig, currentServerId } = useServers()
+  const { getProviderConfig, currentServerId, currentServer } = useServers()
   const [config, setConfig] = useState<{ url: string; token: string } | null>(null)
 
   const [schedulerStatus, setSchedulerStatus] = useState<SchedulerStatus | null>(null)
@@ -198,6 +198,30 @@ export default function SchedulerScreen() {
       marginTop: theme.spacing.sm,
     },
   })
+
+  if (currentServer?.providerType !== 'molt') {
+    return (
+      <SafeAreaView style={styles.container}>
+        <ScreenHeader title="Scheduler" showBack />
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: theme.spacing.lg,
+          }}
+        >
+          <Text variant="heading2" style={{ marginBottom: theme.spacing.md }}>
+            OpenClaw Only
+          </Text>
+          <Text color="secondary" center style={{ marginBottom: theme.spacing.xl }}>
+            Cron Jobs are only available for OpenClaw servers.
+          </Text>
+          <Button title="Go to Settings" onPress={() => router.push('/settings')} />
+        </View>
+      </SafeAreaView>
+    )
+  }
 
   if (!config) {
     return (

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -175,8 +175,8 @@ export default function SettingsScreen() {
           />
         </Section>
 
-        {/* Control group - hidden for Ollama/Echo */}
-        {currentServer?.providerType !== 'ollama' && currentServer?.providerType !== 'echo' && (
+        {/* Control group - only available for OpenClaw (Molt) servers */}
+        {currentServer?.providerType === 'molt' && (
           <Section showDivider>
             <SettingRow
               icon="grid-outline"


### PR DESCRIPTION
## Summary
This PR adds provider type validation to the Overview and Scheduler screens, restricting these features to OpenClaw (Molt) servers only. Users accessing these screens from non-OpenClaw servers will see a friendly message directing them to Settings.

## Changes
- **Overview Screen**: Added check to display "OpenClaw Only" message if `currentServer.providerType !== 'molt'`
- **Scheduler Screen**: Added check to display "OpenClaw Only" message if `currentServer.providerType !== 'molt'`
- **Settings Screen**: Updated comment and simplified provider type check to explicitly allow only `molt` provider type for the Control group section (previously excluded ollama and echo)
- **Hook Usage**: Updated `useServers()` hook calls to destructure `currentServer` in addition to existing `getProviderConfig` and `currentServerId`

## Implementation Details
- Both Overview and Scheduler screens now perform an early return with a centered message UI when accessed from non-OpenClaw servers
- The UI includes a "Go to Settings" button to allow users to navigate away
- Settings screen now uses a positive check (`=== 'molt'`) instead of negative checks, making the intent clearer
- All three screens now consistently validate the server provider type before rendering feature-specific content

https://claude.ai/code/session_011xrMkxakCvSDSbZAMe5c9o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added server compatibility checks across Overview, Scheduler, and Settings pages. Non-OpenClaw servers now display an informational notice with Settings navigation access.

* **Changes**
  * Overview and Scheduler pages now require OpenClaw/Molt server compatibility.
  * Settings control group for Overview and Cron Jobs visibility updated to only display with compatible server types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->