### PR TITLE
Add Claude provider support to add-server screen

### DIFF
--- a/app/add-server.tsx
+++ b/app/add-server.tsx
@@ -18,6 +18,7 @@ import { useTheme } from '../src/theme'
 const ALL_PROVIDER_OPTIONS: { value: ProviderType; label: string }[] = [
   { value: 'molt', label: 'OpenClaw' },
   { value: 'ollama', label: 'Ollama' },
+  { value: 'claudie', label: 'Claude' },
   ...(Platform.OS === 'ios'
     ? [{ value: 'apple' as ProviderType, label: 'Apple Intelligence' }]
     : []),
@@ -38,7 +39,7 @@ export default function AddServerScreen() {
   const [model, setModel] = useState('')
 
   const needsUrl = providerType !== 'echo' && providerType !== 'apple'
-  const needsToken = providerType === 'molt'
+  const needsToken = providerType === 'molt' || providerType === 'claudie'
 
   const handleAdd = async () => {
     if (needsUrl && !url.trim()) {
@@ -47,7 +48,7 @@ export default function AddServerScreen() {
     }
 
     if (needsToken && !token.trim()) {
-      Alert.alert('Error', 'Token is required for OpenClaw')
+      Alert.alert('Error', providerType === 'claudie' ? 'API Key is required' : 'Token is required')
       return
     }
 
@@ -66,7 +67,13 @@ export default function AddServerScreen() {
 
     await addServer(
       {
-        name: name.trim() || (providerType === 'apple' ? 'Apple Intelligence' : 'New Server'),
+        name:
+          name.trim() ||
+          (providerType === 'apple'
+            ? 'Apple Intelligence'
+            : providerType === 'claudie'
+              ? 'Claude'
+              : 'New Server'),
         url: effectiveUrl,
         clientId: clientId.trim() || 'lumiere-mobile',
         providerType,
@@ -133,7 +140,9 @@ export default function AddServerScreen() {
                     ? 'My Echo Server'
                     : providerType === 'apple'
                       ? 'Apple Intelligence'
-                      : 'My Server'
+                      : providerType === 'claudie'
+                        ? 'My Claude'
+                        : 'My Server'
               }
               autoCapitalize="none"
               autoCorrect={false}
@@ -156,7 +165,11 @@ export default function AddServerScreen() {
                 value={url}
                 onChangeText={setUrl}
                 placeholder={
-                  providerType === 'ollama' ? 'http://localhost:11434' : 'wss://gateway.example.com'
+                  providerType === 'ollama'
+                    ? 'http://localhost:11434'
+                    : providerType === 'claudie'
+                      ? 'https://api.anthropic.com'
+                      : 'wss://gateway.example.com'
                 }
                 autoCapitalize="none"
                 autoCorrect={false}
@@ -201,6 +214,31 @@ export default function AddServerScreen() {
                 autoCorrect={false}
               />
             </View>
+          )}
+
+          {providerType === 'claudie' && (
+            <>
+              <View style={styles.formRow}>
+                <TextInput
+                  label="API Key"
+                  value={token}
+                  onChangeText={setToken}
+                  secureTextEntry
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              </View>
+              <View style={styles.formRow}>
+                <TextInput
+                  label="Model"
+                  value={model}
+                  onChangeText={setModel}
+                  placeholder="claude-sonnet-4-5-20250514"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              </View>
+            </>
           )}
 
           <View style={styles.buttonRow}>


### PR DESCRIPTION
## Summary
Add support for Anthropic's Claude as a new provider option in the server configuration screen, allowing users to connect to Claude via API key.

## Key Changes
- Added 'claudie' provider type to the provider options list with "Claude" label
- Updated token requirement logic to include Claude provider
- Added Claude-specific UI elements:
  - API Key input field (secure text entry)
  - Model selection field with default placeholder "claude-sonnet-4-5-20250514"
- Updated default naming logic to use "Claude" for Claude provider instances
- Added Claude-specific URL placeholder pointing to `https://api.anthropic.com`
- Updated error messaging to distinguish between "Token" (for OpenClaw) and "API Key" (for Claude)
- Improved placeholder text formatting for URL input field

## Implementation Details
- Claude provider follows the same token-based authentication pattern as the existing 'molt' (OpenClaw) provider
- The API Key field uses `secureTextEntry` to mask sensitive input
- Model field is optional with a sensible default placeholder for Claude Sonnet
- Conditional rendering ensures Claude-specific fields only appear when Claude provider is selected

https://claude.ai/code/session_01FvkUj8m3UvNW7Ty2DgmCGY