### PR TITLE
Fix Android onboarding not respecting safe areas

### DIFF
--- a/src/screens/OnboardingFlow.tsx
+++ b/src/screens/OnboardingFlow.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
-import { SafeAreaView, StyleSheet, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import {
   AgentIllustration,


### PR DESCRIPTION
Use SafeAreaView from react-native-safe-area-context instead of the
built-in react-native version, which is iOS-only. With edge-to-edge
enabled on Android, the onboarding content was rendering behind system
bars.

https://claude.ai/code/session_01Jbr7rwv1tAukRjPVKmzdrA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies for improved stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->