### PR TITLE
Add comprehensive foldable device support

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -35,7 +35,6 @@ import {
   useDeviceType,
   useFoldResponsiveValue,
   useFoldState,
-  useIsFoldable,
 } from '../../utils/device'
 import { ChatInput } from './ChatInput'
 import { ChatMessage, Message } from './ChatMessage'
@@ -75,7 +74,6 @@ export function ChatScreen({ providerConfig }: ChatScreenProps) {
 
   // Foldable device support
   const deviceType = useDeviceType()
-  const isFoldable = useIsFoldable()
   const foldState = useFoldState()
   const contentContainerStyle = useContentContainerStyle()
 

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -304,10 +304,7 @@ export function useContentContainerStyle() {
   }
 
   // For tablets and unfolded foldables
-  if (
-    (deviceType === 'tablet' || deviceType === 'foldable') &&
-    width > MAX_CONTENT_WIDTH
-  ) {
+  if ((deviceType === 'tablet' || deviceType === 'foldable') && width > MAX_CONTENT_WIDTH) {
     return {
       maxWidth: MAX_CONTENT_WIDTH,
       alignSelf: 'center' as const,
@@ -340,9 +337,7 @@ export function getHingePosition(): number | null {
  * Hook to get hinge position (reactive)
  */
 export function useHingePosition(): number | null {
-  const [hingePosition, setHingePosition] = useState<number | null>(
-    getHingePosition(),
-  )
+  const [hingePosition, setHingePosition] = useState<number | null>(getHingePosition())
 
   useEffect(() => {
     const subscription = Dimensions.addEventListener('change', () => {


### PR DESCRIPTION
This commit adds full support for foldable Android devices (e.g., Samsung Galaxy Z Fold/Flip series) to provide an optimized user experience across different fold states.

Device Detection Utilities (src/utils/device.ts):
- Added isFoldable() to detect foldable devices based on aspect ratio and screen dimensions
- Added getFoldState() to determine fold state: folded, unfolded, or half-folded (flex mode)
- Added DeviceType 'foldable' to the existing 'phone' and 'tablet' types
- Added useIsFoldable() hook for reactive foldable detection
- Added useFoldState() hook for reactive fold state tracking
- Added useResponsiveValueWithFoldable() for three-way responsive values (phone/foldable/tablet)
- Added useFoldResponsiveValue() to adapt UI based on fold state
- Added getHingePosition() and useHingePosition() for estimating hinge position
- Updated useContentContainerStyle() to handle foldable devices with state-specific max widths
- Added foldable-specific breakpoints and reference dimensions

ChatScreen Component (src/components/chat/ChatScreen.tsx):
- Integrated foldable device hooks for responsive layout
- Applied foldable-aware content container styling
- Adjusted message list padding based on fold state
- Optimized status bar positioning for half-folded (flex mode) state
- Updated createStyles to accept device type and fold state parameters

Features:
- Detects foldable devices using aspect ratio analysis (1.1-1.4 typical for unfolded foldables)
- Adapts UI dynamically when device folds/unfolds
- Provides optimal layout in flex mode (half-folded state)
- Maintains compatibility with existing phone and tablet layouts
- Uses dimension change listeners for real-time adaptation

https://claude.ai/code/session_01NDNUHzeNyNX3GyZGevSeD1