### PR TITLE
Fix Android build failures in gemini-nano and speech-transcription modules

### DIFF
--- a/modules/gemini-nano/android/build.gradle
+++ b/modules/gemini-nano/android/build.gradle
@@ -47,5 +47,5 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
   // Google AI Edge SDK (Gemini Nano)
-  implementation 'com.google.ai.edge:generativeai:0.2.2'
+  implementation 'com.google.ai.edge.aicore:aicore:0.0.1-exp02'
 }

--- a/modules/gemini-nano/android/src/main/AndroidManifest.xml
+++ b/modules/gemini-nano/android/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-sdk tools:overrideLibrary="com.google.ai.edge.aicore" />
+</manifest>

--- a/modules/speech-transcription/android/build.gradle
+++ b/modules/speech-transcription/android/build.gradle
@@ -1,1 +1,46 @@
-apply plugin: 'expo-module-gradle-plugin'
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+group = 'expo.modules.speechtranscription'
+version = '1.0.0'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+if (expoModulesCorePlugin.exists()) {
+  apply from: expoModulesCorePlugin
+  applyKotlinExpoModulesCorePlugin()
+
+  useCoreDependencies()
+  useDefaultAndroidSdkVersions()
+  useExpoPublishing()
+}
+
+android {
+  namespace 'expo.modules.speechtranscription'
+
+  defaultConfig {
+    minSdkVersion 23
+    targetSdkVersion 34
+    versionCode 1
+    versionName "1.0.0"
+  }
+
+  buildTypes {
+    release {
+      minifyEnabled false
+    }
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = '17'
+  }
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+}

--- a/modules/speech-transcription/android/src/main/java/expo/modules/speechtranscription/SpeechTranscriptionModule.kt
+++ b/modules/speech-transcription/android/src/main/java/expo/modules/speechtranscription/SpeechTranscriptionModule.kt
@@ -10,6 +10,7 @@ import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
 import androidx.core.content.ContextCompat
+import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -44,9 +45,9 @@ class SpeechTranscriptionModule : Module() {
         return@AsyncFunction
       }
 
-      val permissionsManager = appContext.permissions
-      if (permissionsManager != null) {
-        permissionsManager.askForPermissionsWithPermissionsManager(
+      if (appContext.permissions != null) {
+        Permissions.askForPermissionsWithPermissionsManager(
+          appContext.permissions,
           promise,
           Manifest.permission.RECORD_AUDIO
         )


### PR DESCRIPTION
- Replace non-existent com.google.ai.edge:generativeai:0.2.2 dependency with the real com.google.ai.edge.aicore:aicore:0.0.1-exp02 artifact
- Rewrite GeminiNanoModule to use the actual aicore SDK API (GenerationConfig builder DSL, string-based generateContent/Stream)
- Add AndroidManifest with tools:overrideLibrary for aicore minSdk 31
- Fix speech-transcription build.gradle from stub to full config (namespace, defaultConfig, compile options, dependencies)
- Fix Permissions.askForPermissionsWithPermissionsManager static call