### PR TITLE
Update app.json: Remove requiresFullScreen and add versionCode

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,6 @@
       "supportsTablet": true,
       "bundleIdentifier": "bot.lumiere.app",
       "buildNumber": "1",
-      "requiresFullScreen": false,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSMicrophoneUsageDescription": "Lumiere needs access to your microphone to transcribe voice messages.",
@@ -36,6 +35,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
+      "versionCode": 1,
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "intentFilters": [


### PR DESCRIPTION
## Summary
Updated the app configuration to remove an unused iOS setting and add the Android version code for proper app versioning on the Google Play Store.

## Changes
- **Removed** `requiresFullScreen: false` from iOS configuration (redundant default setting)
- **Added** `versionCode: 1` to Android configuration for proper version tracking in Google Play Store

## Details
The `requiresFullScreen` property is not necessary as `false` is the default behavior for iOS apps. The addition of `versionCode` ensures the Android build has proper version management, which is required by Google Play Store for app updates and distribution.

https://claude.ai/code/session_01MgQeVpPaB96LGjir2ujFBM