### PR TITLE
Fix Android versionCode overflow by using run_number instead of run_id

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Set Android build number
         run: |
-          BUILD_NUMBER="${{ github.run_id }}"
+          BUILD_NUMBER="${{ github.run_number }}"
           npx json -I -f app.json -e "this.expo.android.versionCode=${BUILD_NUMBER:-1}"
 
       - name: Build Android app

--- a/.github/workflows/deploy-android-testing.yml
+++ b/.github/workflows/deploy-android-testing.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set Android build number
         run: |
-          BUILD_NUMBER="${{ github.run_id }}"
+          BUILD_NUMBER="${{ github.run_number }}"
           npx json -I -f app.json -e "this.expo.android.versionCode=${BUILD_NUMBER:-1}"
 
       - name: Build Android app


### PR DESCRIPTION
github.run_id is a globally unique large integer that can exceed the max allowed value for Android versionCode (2147483647), causing build failures. Switch to github.run_number which is a sequential per-workflow counter that stays within bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build process configuration to use an alternative build numbering method for version tracking. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->