### PR TITLE
Replace expo-background-fetch with expo-background-task

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@shopify/flash-list": "2.0.2",
     "expo": "~54.0.33",
     "expo-av": "^16.0.8",
-    "expo-background-fetch": "^14.0.9",
+    "expo-background-task": "^1.0.10",
     "expo-calendar": "^15.0.8",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "^18.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       expo-av:
         specifier: ^16.0.8
         version: 16.0.8(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-background-fetch:
-        specifier: ^14.0.9
-        version: 14.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))
+      expo-background-task:
+        specifier: ^1.0.10
+        version: 1.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))
       expo-calendar:
         specifier: ^15.0.8
         version: 15.0.8(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))
@@ -2476,8 +2476,8 @@ packages:
       react-native-web:
         optional: true
 
-  expo-background-fetch@14.0.9:
-    resolution: {integrity: sha512-IhdbjIu9EdsYaL7mCCvf/i48Qy4a5rpRy038/4KNUoa9xmsETRwFCdsoZj4VHg4dVt2D0kiDrgqVVlPBSSWt+Q==}
+  expo-background-task@1.0.10:
+    resolution: {integrity: sha512-EbPnuf52Ps/RJiaSFwqKGT6TkvMChv7bI0wF42eADbH3J2EMm5y5Qvj0oFmF1CBOwc3mUhqj63o7Pl6OLkGPZQ==}
     peerDependencies:
       expo: '*'
 
@@ -3488,24 +3488,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -7943,7 +7947,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)
 
-  expo-background-fetch@14.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)):
+  expo-background-task@1.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       expo: 54.0.33(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-task-manager: 14.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))


### PR DESCRIPTION
## Summary
Migrates the background notification checking functionality from the deprecated `expo-background-fetch` library to the newer `expo-background-task` library.

## Key Changes
- **Dependency Update**: Replaced `expo-background-fetch@^14.0.9` with `expo-background-task@^1.0.10` in package.json and lock file
- **Import Migration**: Updated import statement from `expo-background-fetch` to `expo-background-task`
- **API Refactoring**: 
  - Changed return type from `BackgroundFetchResult` to `BackgroundTaskResult`
  - Simplified return logic to always return `BackgroundTaskResult.Success` on completion (removed distinction between `NewData` and `NoData`)
  - Removed status checking logic that was specific to the old API
- **Function Simplification**: Removed OS permission checks (`getStatusAsync`) as they are no longer needed with the new library
- **Documentation Updates**: Updated JSDoc comments to reflect the new "background task" terminology

## Implementation Details
- The new `expo-background-task` API has a simpler interface that doesn't require status checks before registration
- Return values are now unified to `Success` or `Failed`, removing the granular `NewData`/`NoData` distinction
- The core functionality remains unchanged - the task still checks for new messages and fires notifications as before
- Lock file also includes minor updates to `lightningcss` package specifications with explicit `libc` constraints

https://claude.ai/code/session_0114QRQUoA5LRaQjeahRf5a7