### PR TITLE
Disable biometric auth requirement for secure token storage

### DIFF
--- a/src/services/secureTokenStorage.ts
+++ b/src/services/secureTokenStorage.ts
@@ -8,7 +8,9 @@ const TOKEN_PREFIX = 'server_token_'
  * @param token - The authentication token
  */
 export async function setServerToken(serverId: string, token: string): Promise<void> {
-  await SecureStore.setItemAsync(`${TOKEN_PREFIX}${serverId}`, token)
+  await SecureStore.setItemAsync(`${TOKEN_PREFIX}${serverId}`, token, {
+    requireAuthentication: false,
+  })
 }
 
 /**
@@ -17,7 +19,16 @@ export async function setServerToken(serverId: string, token: string): Promise<v
  * @returns The token or null if not found
  */
 export async function getServerToken(serverId: string): Promise<string | null> {
-  return await SecureStore.getItemAsync(`${TOKEN_PREFIX}${serverId}`)
+  try {
+    return await SecureStore.getItemAsync(`${TOKEN_PREFIX}${serverId}`, {
+      requireAuthentication: false,
+    })
+  } catch (error) {
+    // If keychain access fails (e.g., "User interaction is not allowed"),
+    // return null instead of throwing an error
+    console.warn(`Failed to retrieve token for server ${serverId}:`, error)
+    return null
+  }
 }
 
 /**
@@ -25,5 +36,12 @@ export async function getServerToken(serverId: string): Promise<string | null> {
  * @param serverId - The server's UUID
  */
 export async function deleteServerToken(serverId: string): Promise<void> {
-  await SecureStore.deleteItemAsync(`${TOKEN_PREFIX}${serverId}`)
+  try {
+    await SecureStore.deleteItemAsync(`${TOKEN_PREFIX}${serverId}`, {
+      requireAuthentication: false,
+    })
+  } catch (error) {
+    // If keychain deletion fails, log but don't throw
+    console.warn(`Failed to delete token for server ${serverId}:`, error)
+  }
 }


### PR DESCRIPTION
## Summary
Updated secure token storage operations to disable biometric authentication requirements and add error handling for keychain access failures.

## Key Changes
- Modified `setServerToken()` to pass `requireAuthentication: false` option to `SecureStore.setItemAsync()`
- Updated `getServerToken()` to:
  - Pass `requireAuthentication: false` option to `SecureStore.getItemAsync()`
  - Add try-catch error handling to gracefully handle keychain access failures (e.g., "User interaction is not allowed")
  - Return `null` on error instead of throwing
- Updated `deleteServerToken()` to:
  - Pass `requireAuthentication: false` option to `SecureStore.deleteItemAsync()`
  - Add try-catch error handling to log failures without throwing

## Implementation Details
- All three token operations now consistently disable the biometric authentication requirement, allowing tokens to be accessed without user interaction
- Error handling logs warnings to console for debugging while preventing crashes
- This change improves reliability in scenarios where keychain access is restricted (e.g., background operations, headless environments)

https://claude.ai/code/session_017oa3MtU2iQxNNA31SWa6YV