### PR TITLE
Hide session menu dots on iPad/foldable where sidebar is available

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -600,7 +600,7 @@ export function ChatScreen({ providerConfig }: ChatScreenProps) {
         <Animated.View style={inputContainerStyle} onLayout={handleInputLayout}>
           <ChatInput
             onSend={handleSend}
-            onOpenSessionMenu={handleOpenSessionMenu}
+            onOpenSessionMenu={deviceType === 'phone' ? handleOpenSessionMenu : undefined}
             disabled={!connected}
             queueCount={queueCount}
             supportsImageAttachments={capabilities.imageAttachments}


### PR DESCRIPTION
On tablets and foldable devices, session management is already accessible
via the sidebar. Remove the redundant 3-dot menu button from ChatInput
on these device types by only passing onOpenSessionMenu on phones.

https://claude.ai/code/session_01B6BmVx3ENKPmPtUReKY1Fz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted session menu access to phone devices for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->