### PR TITLE
Remove background from agent response bubbles to utilize more width

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -558,8 +558,9 @@ const createStyles = (theme: Theme) =>
     },
     agentBubble: {
       width: '100%',
-      backgroundColor: theme.colors.message.agent,
-      borderBottomLeftRadius: theme.borderRadius.sm,
+      backgroundColor: 'transparent',
+      borderRadius: 0,
+      paddingHorizontal: 0,
     },
     intentActions: {
       flexDirection: 'row',


### PR DESCRIPTION
Set agent bubble backgroundColor to transparent, removed border-radius,
and removed horizontal padding so responses span the full available width
without a constraining background container.

https://claude.ai/code/session_01NNzbdtqTwmJuHR6BYu9RsL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified agent message bubble styling in the chat interface: background is now transparent, corners are no longer rounded, and horizontal padding has been removed for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->