### PR TITLE
Add OpenRouter and Gemini Nano provider support

### DIFF
--- a/src/hooks/useServers.ts
+++ b/src/hooks/useServers.ts
@@ -124,14 +124,13 @@ export function useServers(): UseServersResult {
   const getProviderConfig = useCallback(async (): Promise<ProviderConfig | null> => {
     if (!currentServer) return null
     const token = await getServerToken(currentServer.id)
-    // Ollama, Echo, and Apple don't require a token, Molt does
-    if (
-      !token &&
-      currentServer.providerType !== 'ollama' &&
-      currentServer.providerType !== 'echo' &&
-      currentServer.providerType !== 'apple'
-    )
-      return null
+    // Only molt, claude, openai, and openrouter require a token
+    const tokenRequired =
+      currentServer.providerType === 'molt' ||
+      currentServer.providerType === 'claude' ||
+      currentServer.providerType === 'openai' ||
+      currentServer.providerType === 'openrouter'
+    if (!token && tokenRequired) return null
     return {
       type: currentServer.providerType || 'molt',
       url: currentServer.url,
@@ -148,13 +147,12 @@ export function useServers(): UseServersResult {
       const server = servers[id]
       if (!server) return null
       const token = await getServerToken(id)
-      if (
-        !token &&
-        server.providerType !== 'ollama' &&
-        server.providerType !== 'echo' &&
-        server.providerType !== 'apple'
-      )
-        return null
+      const tokenRequired =
+        server.providerType === 'molt' ||
+        server.providerType === 'claude' ||
+        server.providerType === 'openai' ||
+        server.providerType === 'openrouter'
+      if (!token && tokenRequired) return null
       return {
         type: server.providerType || 'molt',
         url: server.url,


### PR DESCRIPTION
## Summary
This PR adds support for two new AI providers (OpenRouter and Gemini Nano) and refactors provider configuration logic to be more maintainable and consistent across the codebase.

## Key Changes

- **New Providers**: Added support for OpenRouter and Gemini Nano (on-device) providers
- **Refactored URL Requirements**: Simplified `needsUrl` logic to explicitly check for providers that require URLs (ollama, molt) instead of negating a list
- **Refactored Token Requirements**: Updated token requirement checks to explicitly list providers that need tokens (molt, claude, openai, openrouter)
- **Default Server Names**: Extracted default server naming logic into a `DEFAULT_SERVER_NAMES` constant and `defaultServerName()` helper function to reduce duplication
- **Unified API Key Forms**: Consolidated Claude, OpenAI, and OpenRouter API key/model input forms into a single conditional block with provider-specific placeholders
- **Improved Edit Screen**: Simplified URL field visibility logic and updated default URL handling for new providers

## Implementation Details

- The `needsUrl` helper in `edit-server.tsx` now uses a cleaner positive assertion pattern
- Token requirement logic now uses a `tokenRequired` variable for better readability
- Default server names are centralized, making it easier to add new providers in the future
- Model placeholder text is now provider-aware (e.g., "openai/gpt-4o" for OpenRouter)
- Gemini Nano displays an informational message about device compatibility requirements

https://claude.ai/code/session_01KZJF1CDga5XVWrmQJfVARk