### PR TITLE
Add support for Gemini Nano and OpenRouter providers

### DIFF
--- a/app/add-server.tsx
+++ b/app/add-server.tsx
@@ -25,12 +25,14 @@ export default function AddServerScreen() {
   const needsUrl =
     providerType !== 'echo' &&
     providerType !== 'apple' &&
+    providerType !== 'gemini-nano' &&
     providerType !== 'claude' &&
     providerType !== 'openai'
   const needsToken =
     providerType === 'molt' ||
     providerType === 'claude' ||
     providerType === 'openai' ||
+    providerType === 'openrouter' ||
     providerType === 'emergent'
 
   const handleAdd = async () => {
@@ -58,10 +60,15 @@ export default function AddServerScreen() {
     } else if (providerType === 'apple') {
       effectiveUrl = 'apple://on-device'
       effectiveToken = 'apple-no-token'
+    } else if (providerType === 'gemini-nano') {
+      effectiveUrl = 'gemini-nano://on-device'
+      effectiveToken = 'gemini-nano-no-token'
     } else if (providerType === 'claude' && !effectiveUrl) {
       effectiveUrl = 'https://api.anthropic.com'
     } else if (providerType === 'openai' && !effectiveUrl) {
       effectiveUrl = 'https://api.openai.com'
+    } else if (providerType === 'openrouter' && !effectiveUrl) {
+      effectiveUrl = 'https://openrouter.ai'
     } else if (providerType === 'emergent' && !effectiveUrl) {
       effectiveUrl = 'https://api.emergent.sh'
     }
@@ -76,13 +83,17 @@ export default function AddServerScreen() {
           name.trim() ||
           (providerType === 'apple'
             ? 'Apple Intelligence'
-            : providerType === 'claude'
-              ? 'Claude'
-              : providerType === 'openai'
-                ? 'OpenAI'
-                : providerType === 'emergent'
-                  ? 'Emergent'
-                  : 'New Server'),
+            : providerType === 'gemini-nano'
+              ? 'Gemini Nano'
+              : providerType === 'claude'
+                ? 'Claude'
+                : providerType === 'openai'
+                  ? 'OpenAI'
+                  : providerType === 'openrouter'
+                    ? 'OpenRouter'
+                    : providerType === 'emergent'
+                      ? 'Emergent'
+                      : 'New Server'),
         url: effectiveUrl,
         clientId: clientId.trim() || 'lumiere-mobile',
         providerType,
@@ -149,13 +160,17 @@ export default function AddServerScreen() {
                     ? 'My Echo Server'
                     : providerType === 'apple'
                       ? 'Apple Intelligence'
-                      : providerType === 'claude'
-                        ? 'My Claude'
-                        : providerType === 'openai'
-                          ? 'My OpenAI'
-                          : providerType === 'emergent'
-                            ? 'My Emergent'
-                            : 'My Server'
+                      : providerType === 'gemini-nano'
+                        ? 'Gemini Nano'
+                        : providerType === 'claude'
+                          ? 'My Claude'
+                          : providerType === 'openai'
+                            ? 'My OpenAI'
+                            : providerType === 'openrouter'
+                              ? 'My OpenRouter'
+                              : providerType === 'emergent'
+                                ? 'My Emergent'
+                                : 'My Server'
               }
               autoCapitalize="none"
               autoCorrect={false}
@@ -167,6 +182,15 @@ export default function AddServerScreen() {
               <Text variant="caption" color="secondary">
                 Uses Apple Foundation Models to run AI entirely on-device via CoreML. Requires iOS
                 26+ with Apple Intelligence support.
+              </Text>
+            </View>
+          )}
+
+          {providerType === 'gemini-nano' && (
+            <View style={styles.formRow}>
+              <Text variant="caption" color="secondary">
+                Uses Google Gemini Nano to run AI entirely on-device. Requires Android 14+ with
+                Gemini Nano support.
               </Text>
             </View>
           )}
@@ -297,6 +321,31 @@ export default function AddServerScreen() {
                   value={model}
                   onChangeText={setModel}
                   placeholder="claude-sonnet-4-5-20250514"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              </View>
+            </>
+          )}
+
+          {providerType === 'openrouter' && (
+            <>
+              <View style={styles.formRow}>
+                <TextInput
+                  label="API Key"
+                  value={token}
+                  onChangeText={setToken}
+                  secureTextEntry
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              </View>
+              <View style={styles.formRow}>
+                <TextInput
+                  label="Model"
+                  value={model}
+                  onChangeText={setModel}
+                  placeholder="openai/gpt-4o"
                   autoCapitalize="none"
                   autoCorrect={false}
                 />

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -62,7 +62,10 @@ export function SetupScreen() {
 
   const needsUrl = providerType === 'molt' || providerType === 'ollama'
   const needsToken =
-    providerType === 'molt' || providerType === 'claude' || providerType === 'openai'
+    providerType === 'molt' ||
+    providerType === 'claude' ||
+    providerType === 'openai' ||
+    providerType === 'openrouter'
 
   const handleComplete = async () => {
     if (providerType === 'molt' && localUrl.trim() && localToken.trim()) {
@@ -141,6 +144,25 @@ export function SetupScreen() {
       }))
 
       setOnboardingCompleted(true)
+    } else if (providerType === 'openrouter' && localToken.trim()) {
+      const serverId = await addServer(
+        {
+          name: 'My OpenRouter',
+          url: localUrl.trim() || 'https://openrouter.ai',
+          providerType: 'openrouter',
+          model: localModel.trim() || undefined,
+        },
+        localToken.trim(),
+      )
+
+      const sessionKey = DEFAULT_SESSION_KEY
+      setCurrentSessionKey(sessionKey)
+      setServerSessions((prev) => ({
+        ...prev,
+        [serverId]: sessionKey,
+      }))
+
+      setOnboardingCompleted(true)
     } else if (providerType === 'echo') {
       const serverId = await addServer(
         {
@@ -177,13 +199,31 @@ export function SetupScreen() {
       }))
 
       setOnboardingCompleted(true)
+    } else if (providerType === 'gemini-nano') {
+      const serverId = await addServer(
+        {
+          name: 'Gemini Nano',
+          url: '',
+          providerType: 'gemini-nano',
+        },
+        '',
+      )
+
+      const sessionKey = DEFAULT_SESSION_KEY
+      setCurrentSessionKey(sessionKey)
+      setServerSessions((prev) => ({
+        ...prev,
+        [serverId]: sessionKey,
+      }))
+
+      setOnboardingCompleted(true)
     }
   }
 
   const isValid =
     providerType === 'molt'
       ? localUrl.trim().length > 0 && localToken.trim().length > 0
-      : providerType === 'claude' || providerType === 'openai'
+      : providerType === 'claude' || providerType === 'openai' || providerType === 'openrouter'
         ? localToken.trim().length > 0
         : providerType === 'ollama'
           ? localUrl.trim().length > 0
@@ -233,11 +273,19 @@ export function SetupScreen() {
 
           {needsToken && (
             <TextInput
-              label={providerType === 'claude' || providerType === 'openai' ? 'API Key' : 'Token'}
+              label={
+                providerType === 'claude' ||
+                providerType === 'openai' ||
+                providerType === 'openrouter'
+                  ? 'API Key'
+                  : 'Token'
+              }
               value={localToken}
               onChangeText={setLocalToken}
               placeholder={
-                providerType === 'claude' || providerType === 'openai'
+                providerType === 'claude' ||
+                providerType === 'openai' ||
+                providerType === 'openrouter'
                   ? 'Your API key'
                   : 'Your authentication token'
               }
@@ -249,14 +297,17 @@ export function SetupScreen() {
                   ? 'Your Anthropic API key'
                   : providerType === 'openai'
                     ? 'Your OpenAI API key'
-                    : 'Your authentication token for the gateway'
+                    : providerType === 'openrouter'
+                      ? 'Your OpenRouter API key'
+                      : 'Your authentication token for the gateway'
               }
             />
           )}
 
           {(providerType === 'ollama' ||
             providerType === 'claude' ||
-            providerType === 'openai') && (
+            providerType === 'openai' ||
+            providerType === 'openrouter') && (
             <TextInput
               label="Model"
               value={localModel}
@@ -266,7 +317,9 @@ export function SetupScreen() {
                   ? 'llama3.2'
                   : providerType === 'claude'
                     ? 'claude-sonnet-4-5-20250514'
-                    : 'gpt-4o'
+                    : providerType === 'openai'
+                      ? 'gpt-4o'
+                      : 'openai/gpt-4o'
               }
               autoCapitalize="none"
               autoCorrect={false}
@@ -275,7 +328,9 @@ export function SetupScreen() {
                   ? 'Ollama model to use (default: llama3.2)'
                   : providerType === 'claude'
                     ? 'Claude model to use (default: claude-sonnet-4-5)'
-                    : 'OpenAI model to use (default: gpt-4o)'
+                    : providerType === 'openai'
+                      ? 'OpenAI model to use (default: gpt-4o)'
+                      : 'OpenRouter model to use (default: openai/gpt-4o)'
               }
             />
           )}


### PR DESCRIPTION
## Summary
This PR adds support for two new AI provider types: Google Gemini Nano (on-device) and OpenRouter (API-based). Both providers are integrated into the server setup flow with appropriate configuration options.

## Key Changes

### Gemini Nano Support
- Added `gemini-nano` as a provider type that doesn't require a URL or token (on-device execution)
- Uses special protocol `gemini-nano://on-device` with placeholder token
- Added informational text explaining Android 14+ requirement
- Integrated into both AddServerScreen and SetupScreen flows

### OpenRouter Support
- Added `openrouter` as a provider type requiring API key and model configuration
- Default URL: `https://openrouter.ai`
- Requires API key (token) and optional model field (defaults to `openai/gpt-4o`)
- Integrated into both AddServerScreen and SetupScreen flows

### UI/UX Updates
- Updated provider type conditionals throughout to include new providers
- Added appropriate placeholder text and labels for OpenRouter model field
- Expanded nested ternary operators to accommodate new provider options
- Added dedicated form sections for OpenRouter API key and model inputs

## Implementation Details
- Both providers follow existing patterns for provider-specific configuration
- Gemini Nano is treated similarly to Apple Intelligence (on-device, no auth needed)
- OpenRouter is treated similarly to Claude/OpenAI (API-based, requires authentication)
- Model field is now conditionally shown for Ollama, Claude, OpenAI, and OpenRouter
- Validation logic updated to handle new provider requirements

https://claude.ai/code/session_018NZLnEuACQLHD4ykfLs8Sa