### PR TITLE
Add OpenRouter provider support to edit server screen

### DIFF
--- a/app/edit-server.tsx
+++ b/app/edit-server.tsx
@@ -32,7 +32,9 @@ export default function EditServerScreen() {
       providerType !== 'echo' &&
       providerType !== 'apple' &&
       providerType !== 'claude' &&
-      providerType !== 'openai'
+      providerType !== 'openai' &&
+      providerType !== 'openrouter' &&
+      providerType !== 'emergent'
     if (needsUrlRequired && !url.trim()) {
       Alert.alert('Error', 'URL is required')
       return
@@ -47,6 +49,8 @@ export default function EditServerScreen() {
       effectiveUrl = 'https://api.anthropic.com'
     } else if (providerType === 'openai' && !effectiveUrl) {
       effectiveUrl = 'https://api.openai.com'
+    } else if (providerType === 'openrouter' && !effectiveUrl) {
+      effectiveUrl = 'https://openrouter.ai'
     } else if (providerType === 'emergent' && !effectiveUrl) {
       effectiveUrl = 'https://api.emergent.sh'
     }
@@ -151,9 +155,11 @@ export default function EditServerScreen() {
                       ? 'My Claude'
                       : providerType === 'openai'
                         ? 'My OpenAI'
-                        : providerType === 'emergent'
-                          ? 'My Emergent'
-                          : 'My Server'
+                        : providerType === 'openrouter'
+                          ? 'My OpenRouter'
+                          : providerType === 'emergent'
+                            ? 'My Emergent'
+                            : 'My Server'
               }
               autoCapitalize="none"
               autoCorrect={false}
@@ -163,7 +169,9 @@ export default function EditServerScreen() {
           {providerType !== 'echo' &&
             providerType !== 'apple' &&
             providerType !== 'claude' &&
-            providerType !== 'openai' && (
+            providerType !== 'openai' &&
+            providerType !== 'openrouter' &&
+            providerType !== 'emergent' && (
               <View style={styles.formRow}>
                 <TextInput
                   label="URL"
@@ -223,6 +231,7 @@ export default function EditServerScreen() {
 
           {(providerType === 'claude' ||
             providerType === 'openai' ||
+            providerType === 'openrouter' ||
             providerType === 'emergent') && (
             <>
               <View style={styles.formRow}>
@@ -243,9 +252,11 @@ export default function EditServerScreen() {
                   placeholder={
                     providerType === 'openai'
                       ? 'gpt-4o'
-                      : providerType === 'emergent'
-                        ? 'claude-sonnet-4-5-20250514'
-                        : 'claude-sonnet-4-5-20250514'
+                      : providerType === 'openrouter'
+                        ? 'openai/gpt-4o'
+                        : providerType === 'emergent'
+                          ? 'claude-sonnet-4-5-20250514'
+                          : 'claude-sonnet-4-5-20250514'
                   }
                   autoCapitalize="none"
                   autoCorrect={false}


### PR DESCRIPTION
## Summary
Added support for the OpenRouter AI provider to the edit server configuration screen, bringing feature parity with other supported providers like Claude, OpenAI, and Emergent.

## Key Changes
- Added `openrouter` to provider type validation checks to exclude it from requiring a custom URL input
- Set default API URL to `https://openrouter.ai` when no URL is provided for OpenRouter
- Updated default server name generation to display "My OpenRouter" for the OpenRouter provider type
- Added OpenRouter to the conditional rendering for API key and model configuration sections
- Set appropriate default model placeholder (`openai/gpt-4o`) for OpenRouter provider

## Implementation Details
- OpenRouter is now treated as a first-class provider alongside Claude, OpenAI, and Emergent
- The provider follows the same pattern as other built-in providers: auto-populated API URL, required API key, and configurable model selection
- Model naming convention for OpenRouter uses the format `provider/model-name` (e.g., `openai/gpt-4o`)

https://claude.ai/code/session_01D9fKEMEUTLjQhpiJygxUqg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenRouter is now available as a server provider with automatic URL configuration for easy setup
  * Emergent is now available as a server provider
  * Model input fields and API token configuration now fully support both OpenRouter and Emergent
  * Configuration interface properly handles provider-specific settings and formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->