### PR TITLE
Add Android configuration to EAS production build settings

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -13,6 +13,10 @@
     "production": {
       "ios": {
         "ascAppId": "6758534255"
+      },
+      "android": {
+        "track": "internal",
+        "releaseStatus": "draft"
       }
     }
   }


### PR DESCRIPTION
## Summary
Added Android-specific build configuration to the EAS production environment, enabling Android app builds with predefined release settings.

## Changes
- Added `android` configuration block to the production environment in `eas.json`
- Set Android release track to `internal` for internal testing distribution
- Set release status to `draft` to prevent automatic release to end users

## Details
This configuration allows Android builds to be generated through EAS with the same production environment setup as iOS, while maintaining a draft status for quality assurance before public release. The internal track setting ensures builds are distributed to internal testers only.

https://claude.ai/code/session_0163JHjHDpV7USJVgCrQUXvk