### PR TITLE
Enable cursor-based text selection on response messages

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -8,6 +8,7 @@ import { useAtom, useSetAtom } from 'jotai'
 import React, { useCallback, useMemo, useState } from 'react'
 import {
   Image,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
@@ -557,12 +558,14 @@ const createStyles = (theme: Theme) =>
       maxWidth: '80%',
       backgroundColor: theme.colors.message.user,
       borderBottomRightRadius: theme.borderRadius.sm,
+      ...(Platform.OS === 'web' ? { userSelect: 'text' as const } : {}),
     },
     agentBubble: {
       width: '100%',
       backgroundColor: 'transparent',
       borderRadius: 0,
       paddingHorizontal: 0,
+      ...(Platform.OS === 'web' ? { userSelect: 'text' as const } : {}),
     },
     intentActions: {
       flexDirection: 'row',
@@ -630,6 +633,7 @@ const createMarkdownStyles = (theme: Theme, isUser: boolean) => {
       color: textColor,
       fontSize: theme.typography.fontSize.base,
       lineHeight: theme.typography.fontSize.base * theme.typography.lineHeight.normal,
+      ...(Platform.OS === 'web' ? { userSelect: 'text' as const } : {}),
     },
     text: {
       color: textColor,


### PR DESCRIPTION
Add Platform-aware userSelect styles to message bubbles and markdown
body so response text can be selected with a cursor on web, while
preserving the existing selectable={true} behavior on native.

https://claude.ai/code/session_01WP9sGshUABoesXLmCyE2Yf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text in chat messages is now selectable on web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->