### PR TITLE
Fix attachment menu closing on content press

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -162,41 +162,43 @@ export function ChatInput({
         onRequestClose={() => setShowAttachmentMenu(false)}
       >
         <Pressable style={styles.modalOverlay} onPress={() => setShowAttachmentMenu(false)}>
-          <View style={styles.attachmentMenu}>
-            <TouchableOpacity
-              style={styles.attachmentOption}
-              onPress={handlePickImage}
-              accessibilityRole="button"
-              accessibilityLabel="Attach picture"
-            >
-              <View style={styles.attachmentIconContainer}>
-                <Ionicons name="image" size={24} color={theme.colors.primary} />
-              </View>
-              <Text style={styles.attachmentOptionText}>Picture</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.attachmentOption}
-              onPress={handlePickVideo}
-              accessibilityRole="button"
-              accessibilityLabel="Attach video"
-            >
-              <View style={styles.attachmentIconContainer}>
-                <Ionicons name="videocam" size={24} color={theme.colors.primary} />
-              </View>
-              <Text style={styles.attachmentOptionText}>Video</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.attachmentOption}
-              onPress={handlePickFile}
-              accessibilityRole="button"
-              accessibilityLabel="Attach file"
-            >
-              <View style={styles.attachmentIconContainer}>
-                <Ionicons name="document" size={24} color={theme.colors.primary} />
-              </View>
-              <Text style={styles.attachmentOptionText}>File</Text>
-            </TouchableOpacity>
-          </View>
+          <Pressable>
+            <View style={styles.attachmentMenu}>
+              <TouchableOpacity
+                style={styles.attachmentOption}
+                onPress={handlePickImage}
+                accessibilityRole="button"
+                accessibilityLabel="Attach picture"
+              >
+                <View style={styles.attachmentIconContainer}>
+                  <Ionicons name="image" size={24} color={theme.colors.primary} />
+                </View>
+                <Text style={styles.attachmentOptionText}>Picture</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.attachmentOption}
+                onPress={handlePickVideo}
+                accessibilityRole="button"
+                accessibilityLabel="Attach video"
+              >
+                <View style={styles.attachmentIconContainer}>
+                  <Ionicons name="videocam" size={24} color={theme.colors.primary} />
+                </View>
+                <Text style={styles.attachmentOptionText}>Video</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.attachmentOption}
+                onPress={handlePickFile}
+                accessibilityRole="button"
+                accessibilityLabel="Attach file"
+              >
+                <View style={styles.attachmentIconContainer}>
+                  <Ionicons name="document" size={24} color={theme.colors.primary} />
+                </View>
+                <Text style={styles.attachmentOptionText}>File</Text>
+              </TouchableOpacity>
+            </View>
+          </Pressable>
         </Pressable>
       </Modal>
       {hasInput && suggestions.length > 0 && (


### PR DESCRIPTION
## Summary
Wrapped the attachment menu content in an additional `Pressable` component to prevent the menu from closing when users interact with menu options.

## Changes
- Added a `Pressable` wrapper around the `attachmentMenu` View component
- This allows the inner menu options (Picture, Video, File) to handle their own press events without triggering the outer overlay's `onPress` handler that closes the menu

## Implementation Details
The attachment menu modal has two layers of `Pressable` components:
1. **Outer Pressable** (`modalOverlay`): Closes the menu when the overlay area is pressed
2. **Inner Pressable** (newly added): Prevents press events from bubbling up to the outer layer, allowing menu items to function properly

This is a common pattern in React Native modals to distinguish between overlay dismissal and content interaction.

https://claude.ai/code/session_012rGXNwckQkPz4ypMxbLVJ8