### PR TITLE
Auto-select most recent session when default session is active

### DIFF
--- a/app/sessions.tsx
+++ b/app/sessions.tsx
@@ -6,6 +6,7 @@ import { Alert, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-nat
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { Button, ScreenHeader, Section, SettingRow, Text } from '../src/components/ui'
+import { DEFAULT_SESSION_KEY } from '../src/constants'
 import { useServers } from '../src/hooks/useServers'
 import { useMoltGateway } from '../src/services/molt'
 import { ProviderConfig } from '../src/services/providers'
@@ -71,13 +72,21 @@ export default function SessionsScreen() {
       const sessionData = (await listSessions()) as { sessions?: Session[] }
       if (sessionData?.sessions && Array.isArray(sessionData.sessions)) {
         setSessions(sessionData.sessions)
+
+        // If current session is the default and sessions exist, use the most recent one
+        if (currentSessionKey === DEFAULT_SESSION_KEY && sessionData.sessions.length > 0) {
+          const sortedSessions = [...sessionData.sessions].sort(
+            (a, b) => (b.lastActivity || 0) - (a.lastActivity || 0),
+          )
+          setCurrentSessionKey(sortedSessions[0].key)
+        }
       }
     } catch (err) {
       sessionsLogger.logError('Failed to fetch sessions', err)
     } finally {
       setLoading(false)
     }
-  }, [connected, listSessions, supportsServerSessions])
+  }, [connected, listSessions, supportsServerSessions, currentSessionKey, setCurrentSessionKey])
 
   useEffect(() => {
     loadSessions()


### PR DESCRIPTION
## Summary
Updated the session loading logic to automatically switch to the most recently active session when the current session is set to the default session key and other sessions are available.

## Key Changes
- Added import of `DEFAULT_SESSION_KEY` constant from the constants module
- Enhanced `loadSessions()` effect to detect when the current session is the default session
- When default session is active and sessions exist, automatically select the most recent session based on `lastActivity` timestamp
- Updated the dependency array of the `useEffect` hook to include `currentSessionKey` and `setCurrentSessionKey` to ensure proper effect re-execution

## Implementation Details
- Sessions are sorted by `lastActivity` in descending order to identify the most recent session
- The logic only triggers when `currentSessionKey === DEFAULT_SESSION_KEY`, preventing unnecessary switches for explicitly selected sessions
- Uses a safe sort approach by spreading the sessions array to avoid mutating the original state
- Handles edge cases where `lastActivity` may be undefined by defaulting to 0 in the comparison

https://claude.ai/code/session_01Y7U4bNF4tBNE7fBuALS6ms