### PR TITLE
Fix media picker not launching after tapping attachment menu options

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -62,6 +62,9 @@ export function ChatInput({
 
   const handlePickImage = async () => {
     setShowAttachmentMenu(false)
+    // Wait for modal dismiss animation to complete before presenting system picker.
+    // Without this delay, the picker silently fails to present on iOS and Android.
+    await new Promise<void>((resolve) => setTimeout(resolve, 500))
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images'],
       allowsMultipleSelection: true,
@@ -83,6 +86,7 @@ export function ChatInput({
 
   const handlePickVideo = async () => {
     setShowAttachmentMenu(false)
+    await new Promise<void>((resolve) => setTimeout(resolve, 500))
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['videos'],
       allowsMultipleSelection: true,
@@ -102,6 +106,7 @@ export function ChatInput({
 
   const handlePickFile = async () => {
     setShowAttachmentMenu(false)
+    await new Promise<void>((resolve) => setTimeout(resolve, 500))
     const result = await DocumentPicker.getDocumentAsync({
       type: '*/*',
       multiple: true,


### PR DESCRIPTION
The modal dismiss animation was racing with the system picker presentation,
causing ImagePicker and DocumentPicker to silently fail on both iOS and
Android. Added a 500ms delay after closing the modal to let the dismiss
animation complete before launching the system picker.

https://claude.ai/code/session_01371mGtUFrDfyEfqaB7gwnj