### PR TITLE
Add "Server Config" section title for Overview and Cron Jobs in settings

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -259,9 +259,9 @@ export default function SettingsScreen() {
           />
         </Section>
 
-        {/* Control group - only available for OpenClaw (Molt) servers */}
+        {/* Server Config - only available for OpenClaw (Molt) servers */}
         {currentServer?.providerType === 'molt' && (
-          <Section showDivider>
+          <Section title={t('settings.serverConfig')} showDivider>
             <SettingRow
               icon="grid-outline"
               label={t('settings.overview')}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -26,6 +26,7 @@
     "favorites": "Favorites",
     "triggers": "Triggers",
     "overview": "Overview",
+    "serverConfig": "Server Config",
     "cronJobs": "Cron Jobs",
     "componentGallery": "Component Gallery",
     "logout": "Logout",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -26,6 +26,7 @@
     "favorites": "Favoritos",
     "triggers": "Disparadores",
     "overview": "Resumen",
+    "serverConfig": "Configuración del Servidor",
     "cronJobs": "Tareas Programadas",
     "componentGallery": "Galería de Componentes",
     "logout": "Cerrar Sesión",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -26,6 +26,7 @@
     "favorites": "Favoris",
     "triggers": "Déclencheurs",
     "overview": "Aperçu",
+    "serverConfig": "Configuration Serveur",
     "cronJobs": "Tâches planifiées",
     "componentGallery": "Galerie de composants",
     "logout": "Déconnexion",


### PR DESCRIPTION
The OpenClaw-specific section containing Overview and Cron Jobs now
displays under a titled "Server Config" section header, with i18n
support for English, Spanish, and French.

https://claude.ai/code/session_013GrermR4FtPUCRNnAuEkuQ