### PR TITLE
Add session support for Claude and all non-Molt providers

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -43,4 +43,6 @@ export const CACHE_CONFIG = {
   MAX_CACHED_MESSAGES: 200,
   /** AsyncStorage key prefix for cached chat messages */
   CACHE_KEY_PREFIX: 'chat_cache:',
+  /** AsyncStorage key prefix for tracking known session keys per server */
+  SESSION_INDEX_PREFIX: 'session_index:',
 } as const

--- a/src/services/providers/index.ts
+++ b/src/services/providers/index.ts
@@ -1,4 +1,11 @@
-export { buildCacheKey, CachedChatProvider, readCachedHistory } from './CachedChatProvider'
+export type { SessionIndexEntry } from './CachedChatProvider'
+export {
+  buildCacheKey,
+  buildSessionIndexKey,
+  CachedChatProvider,
+  readCachedHistory,
+  readSessionIndex,
+} from './CachedChatProvider'
 export { createChatProvider } from './createProvider'
 export { MoltChatProvider } from './MoltChatProvider'
 export type {


### PR DESCRIPTION
Previously, the sessions screen only displayed a session list for Molt
(server-side sessions). Claude and other providers had no way to view,
switch between, or manage multiple sessions from the UI.

This adds a persistent session index to CachedChatProvider that tracks
all session keys per server in AsyncStorage. When a message is sent, the
session is registered in the index with its message count. The sessions
screen now reads from this index for non-Molt providers, making session
management available across all provider types.

https://claude.ai/code/session_01CJia5svS8QYekD78MMw9S1