### PR TITLE
Add OpenAI image generation support

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -39,6 +39,10 @@ export interface MessageAttachment {
   name?: string
 }
 
+export interface GeneratedImage {
+  url: string // base64 data URI
+}
+
 export interface Message {
   id: string
   text: string
@@ -46,6 +50,7 @@ export interface Message {
   timestamp: Date
   streaming?: boolean
   attachments?: MessageAttachment[]
+  generatedImages?: GeneratedImage[]
 }
 
 interface ChatMessageProps {
@@ -433,17 +438,33 @@ export function ChatMessage({ message }: ChatMessageProps) {
             ))}
           </View>
         )}
-        <Markdown
-          style={markdownStyles}
-          onLinkPress={(url: string) => {
-            handleLinkPress(url)
-            return false
-          }}
-          mergeStyle={true}
-          rules={markdownRules}
-        >
-          {processedText}
-        </Markdown>
+        {message.generatedImages && message.generatedImages.length > 0 && (
+          <View style={styles.generatedImageContainer}>
+            {message.generatedImages.map((img, index) => (
+              <Image
+                key={`gen-${index}`}
+                source={{ uri: img.url }}
+                style={styles.generatedImage}
+                resizeMode="contain"
+                accessibilityLabel={`Generated image ${index + 1}`}
+                accessibilityRole="image"
+              />
+            ))}
+          </View>
+        )}
+        {processedText.trim().length > 0 && (
+          <Markdown
+            style={markdownStyles}
+            onLinkPress={(url: string) => {
+              handleLinkPress(url)
+              return false
+            }}
+            mergeStyle={true}
+            rules={markdownRules}
+          >
+            {processedText}
+          </Markdown>
+        )}
         {message.streaming && (
           <Text style={styles.streamingIndicator} selectable={true}>
             ...
@@ -625,6 +646,15 @@ const createStyles = (theme: Theme) =>
       width: 200,
       height: 200,
       borderRadius: theme.borderRadius.md,
+    },
+    generatedImageContainer: {
+      marginBottom: theme.spacing.sm,
+    },
+    generatedImage: {
+      width: '100%',
+      aspectRatio: 1,
+      borderRadius: theme.borderRadius.md,
+      backgroundColor: theme.isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)',
     },
   })
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,11 +15,19 @@ export const DEFAULT_MODELS = {
   OLLAMA: 'llama3.2',
   /** Default OpenAI model */
   OPENAI: 'gpt-4o',
+  /** Default OpenAI image generation model */
+  OPENAI_IMAGE: 'gpt-image-1',
   /** Default OpenRouter model */
   OPENROUTER: 'openai/gpt-4o',
   /** Default Emergent model */
   EMERGENT: 'claude-sonnet-4-5',
 } as const
+
+/**
+ * Known OpenAI image generation model prefixes.
+ * Used to auto-detect when a configured model should use the images API.
+ */
+export const OPENAI_IMAGE_MODELS = ['dall-e-2', 'dall-e-3', 'gpt-image-1'] as const
 
 /**
  * API configuration constants.
@@ -33,6 +41,10 @@ export const API_CONFIG = {
   OPENAI_MAX_TOKENS: 4096,
   /** Default max tokens for OpenRouter API responses */
   OPENROUTER_MAX_TOKENS: 4096,
+  /** Default image size for OpenAI image generation */
+  OPENAI_IMAGE_SIZE: '1024x1024' as string,
+  /** Default image quality for OpenAI image generation */
+  OPENAI_IMAGE_QUALITY: 'auto' as string,
 } as const
 
 /**

--- a/src/hooks/__tests__/useMessageQueue.test.ts
+++ b/src/hooks/__tests__/useMessageQueue.test.ts
@@ -32,6 +32,7 @@ function createMocks() {
   >()
   const onMessageAdd = jest.fn()
   const onAgentMessageUpdate = jest.fn()
+  const onAgentImagesUpdate = jest.fn()
   const onAgentMessageComplete = jest.fn()
   const onSendStart = jest.fn()
 
@@ -40,6 +41,7 @@ function createMocks() {
     currentSessionKey: 'test-session',
     onMessageAdd,
     onAgentMessageUpdate,
+    onAgentImagesUpdate,
     onAgentMessageComplete,
     onSendStart,
   }

--- a/src/services/apple-intelligence/AppleChatProvider.ts
+++ b/src/services/apple-intelligence/AppleChatProvider.ts
@@ -29,6 +29,7 @@ export class AppleChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: false,
+    imageGeneration: false,
     serverSessions: false,
     persistentHistory: false,
     scheduler: false,

--- a/src/services/claude/ClaudeChatProvider.ts
+++ b/src/services/claude/ClaudeChatProvider.ts
@@ -55,6 +55,7 @@ export class ClaudeChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: true,
+    imageGeneration: false,
     serverSessions: false,
     persistentHistory: false,
     scheduler: false,

--- a/src/services/echo/EchoChatProvider.ts
+++ b/src/services/echo/EchoChatProvider.ts
@@ -19,6 +19,7 @@ export class EchoChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: false,
+    imageGeneration: false,
     serverSessions: false,
     persistentHistory: false,
     scheduler: false,

--- a/src/services/emergent/EmergentChatProvider.ts
+++ b/src/services/emergent/EmergentChatProvider.ts
@@ -53,6 +53,7 @@ export class EmergentChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: true,
+    imageGeneration: false,
     serverSessions: false,
     persistentHistory: false,
     scheduler: false,

--- a/src/services/gemini-nano/GeminiNanoChatProvider.ts
+++ b/src/services/gemini-nano/GeminiNanoChatProvider.ts
@@ -29,6 +29,7 @@ export class GeminiNanoChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: false,
+    imageGeneration: false,
     serverSessions: false,
     persistentHistory: false,
     scheduler: false,

--- a/src/services/ollama/OllamaChatProvider.ts
+++ b/src/services/ollama/OllamaChatProvider.ts
@@ -27,6 +27,7 @@ export class OllamaChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: false,
+    imageGeneration: false,
     serverSessions: false,
     persistentHistory: false,
     scheduler: false,

--- a/src/services/openrouter/OpenRouterChatProvider.ts
+++ b/src/services/openrouter/OpenRouterChatProvider.ts
@@ -54,6 +54,7 @@ export class OpenRouterChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: true,
+    imageGeneration: false,
     serverSessions: false,
     persistentHistory: false,
     scheduler: false,

--- a/src/services/providers/MoltChatProvider.ts
+++ b/src/services/providers/MoltChatProvider.ts
@@ -20,6 +20,7 @@ export class MoltChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: true,
+    imageGeneration: false,
     serverSessions: true,
     persistentHistory: true,
     scheduler: true,

--- a/src/services/providers/index.ts
+++ b/src/services/providers/index.ts
@@ -9,6 +9,7 @@ export {
 export { createChatProvider } from './createProvider'
 export { MoltChatProvider } from './MoltChatProvider'
 export type {
+  ChatHistoryContentItem,
   ChatHistoryMessage,
   ChatHistoryResponse,
   ChatProvider,

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -22,11 +22,16 @@ export interface ProviderConfig {
 }
 
 export interface ChatProviderEvent {
-  type: 'delta' | 'lifecycle'
+  type: 'delta' | 'lifecycle' | 'image'
   /** Incremental text chunk (for type === 'delta') */
   delta?: string
   /** Lifecycle phase (for type === 'lifecycle') */
   phase?: 'start' | 'end'
+  /** Generated image data (for type === 'image') */
+  image?: {
+    url: string // base64 data URI (e.g. data:image/png;base64,...)
+    revisedPrompt?: string
+  }
 }
 
 export interface SendMessageParams {
@@ -41,9 +46,16 @@ export interface ProviderAttachment {
   mimeType?: string
 }
 
+export interface ChatHistoryContentItem {
+  type: string
+  text?: string
+  /** Base64 data URI for generated images (e.g. data:image/png;base64,...) */
+  image_url?: string
+}
+
 export interface ChatHistoryMessage {
   role: 'user' | 'assistant'
-  content: Array<{ type: string; text?: string }>
+  content: ChatHistoryContentItem[]
   timestamp: number
 }
 
@@ -67,6 +79,8 @@ export interface ProviderCapabilities {
   chat: boolean
   /** Sending image attachments alongside messages */
   imageAttachments: boolean
+  /** AI image generation (e.g. DALL-E, gpt-image-1) */
+  imageGeneration: boolean
   /** Server-side session persistence (list / switch / reset) */
   serverSessions: boolean
   /** Persistent chat history that survives app restarts */


### PR DESCRIPTION
Integrate OpenAI's Images API (DALL-E, gpt-image-1) into the chat
provider architecture. Users can generate images by either configuring
an image model (dall-e-2, dall-e-3, gpt-image-1) as their server model
or prefixing a message with "/image " when using a regular chat model.

Key changes:
- Extend ChatProviderEvent with 'image' event type for generated images
- Add imageGeneration capability to ProviderCapabilities
- Implement sendImageGeneration in OpenAIChatProvider using /v1/images/generations
- Update ChatMessage to render generated images with full-width display
- Thread image data through useMessageQueue and CachedChatProvider
- Update ChatScreen to handle image content in history and streaming
- Add OPENAI_IMAGE_MODELS constant and API config for image generation

https://claude.ai/code/session_01Ga9Ss2bYHkN7EfC57cDanN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image generation support with multiple available models (DALL-E 2, DALL-E 3, and additional options)
  * Generated images now display in chat conversations with full-width formatting
  * Configurable image generation settings for size and quality

* **Chores**
  * Updated provider capability declarations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->