### PR TITLE
Add Simplified Chinese (zh-CN) and Traditional Chinese (zh-TW) translations

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -5,26 +5,47 @@ import { initReactI18next } from 'react-i18next'
 import en from './locales/en.json'
 import es from './locales/es.json'
 import fr from './locales/fr.json'
+import zhCN from './locales/zh-CN.json'
+import zhTW from './locales/zh-TW.json'
 
 export const resources = {
   en: { translation: en },
   es: { translation: es },
   fr: { translation: fr },
+  'zh-CN': { translation: zhCN },
+  'zh-TW': { translation: zhTW },
 } as const
 
 export const languageNames: Record<string, string> = {
   en: 'English',
   es: 'Español',
   fr: 'Français',
+  'zh-CN': '简体中文',
+  'zh-TW': '繁體中文',
 }
 
 export const supportedLanguages = Object.keys(resources)
 
-// Get device language code (e.g., 'en', 'es')
+// Get device language code (e.g., 'en', 'es', 'zh-CN')
 const getDeviceLanguage = (): string => {
   const locale = Localization.getLocales()[0]
   const languageCode = locale?.languageCode ?? 'en'
-  return supportedLanguages.includes(languageCode) ? languageCode : 'en'
+  const regionCode = locale?.regionCode
+
+  // Check for language-region match first (e.g., zh-CN, zh-TW)
+  if (regionCode) {
+    const langRegion = `${languageCode}-${regionCode}`
+    if (supportedLanguages.includes(langRegion)) {
+      return langRegion
+    }
+  }
+
+  // Fall back to language code only
+  if (supportedLanguages.includes(languageCode)) {
+    return languageCode
+  }
+
+  return 'en'
 }
 
 i18n.use(initReactI18next).init({

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1,0 +1,154 @@
+{
+  "common": {
+    "cancel": "取消",
+    "save": "保存",
+    "delete": "删除",
+    "done": "完成",
+    "error": "错误",
+    "success": "成功",
+    "loading": "加载中...",
+    "retry": "重试",
+    "close": "关闭",
+    "back": "返回",
+    "next": "下一步",
+    "skip": "跳过",
+    "confirm": "确认",
+    "active": "活跃"
+  },
+  "settings": {
+    "title": "设置",
+    "servers": "服务器",
+    "noServersConfigured": "未配置服务器",
+    "general": "通用",
+    "colors": "颜色",
+    "faceId": "面容 ID",
+    "notifications": "通知",
+    "favorites": "收藏",
+    "triggers": "触发器",
+    "overview": "概览",
+    "serverConfig": "服务器配置",
+    "cronJobs": "定时任务",
+    "componentGallery": "组件库",
+    "logout": "退出登录",
+    "logoutConfirmTitle": "退出登录",
+    "logoutConfirmMessage": "确定要退出登录吗？所有服务器和设置将被清除。",
+    "theme": {
+      "light": "浅色",
+      "dark": "深色",
+      "system": "跟随系统"
+    },
+    "biometric": {
+      "unavailable": "不可用",
+      "unavailableMessage": "此设备不支持生物识别认证。",
+      "notEnrolled": "未注册",
+      "notEnrolledMessage": "此设备未注册生物识别凭证。",
+      "enablePrompt": "请验证以启用面容 ID 锁定"
+    },
+    "language": "语言"
+  },
+  "home": {
+    "connectionError": "连接错误",
+    "goToSettings": "前往设置",
+    "noServerConfigured": "未配置服务器",
+    "noServerMessage": "请在设置中添加服务器以开始使用。"
+  },
+  "chat": {
+    "placeholder": "输入消息...",
+    "listening": "正在听...",
+    "startSpeaking": "开始说话...",
+    "send": "发送"
+  },
+  "addServer": {
+    "title": "添加服务器",
+    "providerType": "提供商类型",
+    "name": "名称",
+    "url": "URL",
+    "token": "令牌",
+    "apiKey": "API 密钥",
+    "clientId": "客户端 ID",
+    "model": "模型",
+    "addButton": "添加服务器",
+    "placeholders": {
+      "myServer": "我的服务器",
+      "myOllama": "我的 Ollama",
+      "myEchoServer": "我的回声服务器",
+      "myClaude": "我的 Claude"
+    },
+    "providers": {
+      "openClaw": "OpenClaw",
+      "ollama": "Ollama",
+      "claude": "Claude",
+      "appleIntelligence": "Apple Intelligence",
+      "echoServer": "回声服务器"
+    },
+    "appleDescription": "使用 Apple Foundation Models 通过 CoreML 在设备上完全本地运行 AI。需要 iOS 26+ 并支持 Apple Intelligence。",
+    "errors": {
+      "urlRequired": "URL 为必填项",
+      "tokenRequired": "令牌为必填项",
+      "apiKeyRequired": "API 密钥为必填项"
+    }
+  },
+  "editServer": {
+    "title": "编辑服务器",
+    "saveChanges": "保存更改",
+    "deleteServer": "删除服务器",
+    "deleteConfirmTitle": "删除服务器",
+    "deleteConfirmMessage": "确定要删除此服务器吗？此操作无法撤销。"
+  },
+  "biometricLock": {
+    "locked": "已锁定",
+    "unlock": "解锁",
+    "unlockPrompt": "解锁 Lumiere",
+    "authenticateToUnlock": "请验证以解锁 Lumiere",
+    "failed": "认证失败",
+    "failedMessage": "认证尝试出现问题。\n请重试。",
+    "authFailed": "认证失败。点击重试。",
+    "tryAgain": "重试"
+  },
+  "onboarding": {
+    "step1": {
+      "title": "管理你的 AI 代理从未如此简单",
+      "description": "Lumiere 为你提供精美的移动界面，随时随地与 AI 代理交互。监控对话、发送消息，无论身在何处都能保持连接。"
+    },
+    "step2": {
+      "title": "强大功能，全面掌控",
+      "description": "管理多个服务器，切换会话，使用定时任务调度，获取实时通知。一切尽在掌握。"
+    },
+    "step3": {
+      "title": "高度可配置，满足个性化需求",
+      "description": "连接 OpenClaw、Ollama 或 Echo 提供商。自定义主题，设置深度链接触发器，打造适合你工作流程的体验。"
+    },
+    "getStarted": "开始使用"
+  },
+  "sessions": {
+    "title": "会话",
+    "newSession": "新建会话",
+    "editSession": "编辑会话",
+    "deleteSession": "删除会话",
+    "sessionName": "会话名称",
+    "defaultSession": "默认会话"
+  },
+  "favorites": {
+    "title": "收藏",
+    "noFavorites": "暂无收藏",
+    "addFavorite": "添加到收藏",
+    "removeFavorite": "取消收藏"
+  },
+  "triggers": {
+    "title": "触发器",
+    "newTrigger": "新建触发器",
+    "editTrigger": "编辑触发器",
+    "deleteTrigger": "删除触发器",
+    "noTriggers": "未配置触发器"
+  },
+  "scheduler": {
+    "title": "调度器",
+    "cronJobs": "定时任务"
+  },
+  "gallery": {
+    "title": "组件库"
+  },
+  "overview": {
+    "title": "概览"
+  }
+}

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1,0 +1,154 @@
+{
+  "common": {
+    "cancel": "取消",
+    "save": "儲存",
+    "delete": "刪除",
+    "done": "完成",
+    "error": "錯誤",
+    "success": "成功",
+    "loading": "載入中...",
+    "retry": "重試",
+    "close": "關閉",
+    "back": "返回",
+    "next": "下一步",
+    "skip": "略過",
+    "confirm": "確認",
+    "active": "活躍"
+  },
+  "settings": {
+    "title": "設定",
+    "servers": "伺服器",
+    "noServersConfigured": "未設定伺服器",
+    "general": "一般",
+    "colors": "顏色",
+    "faceId": "Face ID",
+    "notifications": "通知",
+    "favorites": "收藏",
+    "triggers": "觸發器",
+    "overview": "總覽",
+    "serverConfig": "伺服器設定",
+    "cronJobs": "排程任務",
+    "componentGallery": "元件庫",
+    "logout": "登出",
+    "logoutConfirmTitle": "登出",
+    "logoutConfirmMessage": "確定要登出嗎？所有伺服器和設定將被清除。",
+    "theme": {
+      "light": "淺色",
+      "dark": "深色",
+      "system": "跟隨系統"
+    },
+    "biometric": {
+      "unavailable": "不可用",
+      "unavailableMessage": "此裝置不支援生物辨識認證。",
+      "notEnrolled": "未註冊",
+      "notEnrolledMessage": "此裝置未註冊生物辨識憑證。",
+      "enablePrompt": "請驗證以啟用 Face ID 鎖定"
+    },
+    "language": "語言"
+  },
+  "home": {
+    "connectionError": "連線錯誤",
+    "goToSettings": "前往設定",
+    "noServerConfigured": "未設定伺服器",
+    "noServerMessage": "請在設定中新增伺服器以開始使用。"
+  },
+  "chat": {
+    "placeholder": "輸入訊息...",
+    "listening": "正在聆聽...",
+    "startSpeaking": "開始說話...",
+    "send": "傳送"
+  },
+  "addServer": {
+    "title": "新增伺服器",
+    "providerType": "供應商類型",
+    "name": "名稱",
+    "url": "URL",
+    "token": "權杖",
+    "apiKey": "API 金鑰",
+    "clientId": "用戶端 ID",
+    "model": "模型",
+    "addButton": "新增伺服器",
+    "placeholders": {
+      "myServer": "我的伺服器",
+      "myOllama": "我的 Ollama",
+      "myEchoServer": "我的回音伺服器",
+      "myClaude": "我的 Claude"
+    },
+    "providers": {
+      "openClaw": "OpenClaw",
+      "ollama": "Ollama",
+      "claude": "Claude",
+      "appleIntelligence": "Apple Intelligence",
+      "echoServer": "回音伺服器"
+    },
+    "appleDescription": "使用 Apple Foundation Models 透過 CoreML 在裝置上完全本機執行 AI。需要 iOS 26+ 並支援 Apple Intelligence。",
+    "errors": {
+      "urlRequired": "URL 為必填欄位",
+      "tokenRequired": "權杖為必填欄位",
+      "apiKeyRequired": "API 金鑰為必填欄位"
+    }
+  },
+  "editServer": {
+    "title": "編輯伺服器",
+    "saveChanges": "儲存變更",
+    "deleteServer": "刪除伺服器",
+    "deleteConfirmTitle": "刪除伺服器",
+    "deleteConfirmMessage": "確定要刪除此伺服器嗎？此操作無法復原。"
+  },
+  "biometricLock": {
+    "locked": "已鎖定",
+    "unlock": "解鎖",
+    "unlockPrompt": "解鎖 Lumiere",
+    "authenticateToUnlock": "請驗證以解鎖 Lumiere",
+    "failed": "驗證失敗",
+    "failedMessage": "驗證嘗試發生問題。\n請重試。",
+    "authFailed": "驗證失敗。點擊重試。",
+    "tryAgain": "重試"
+  },
+  "onboarding": {
+    "step1": {
+      "title": "管理你的 AI 代理從未如此簡單",
+      "description": "Lumiere 為你提供精美的行動介面，隨時隨地與 AI 代理互動。監控對話、傳送訊息，無論身在何處都能保持連線。"
+    },
+    "step2": {
+      "title": "強大功能，全面掌控",
+      "description": "管理多個伺服器，切換工作階段，使用排程任務調度，取得即時通知。一切盡在掌握。"
+    },
+    "step3": {
+      "title": "高度可設定，滿足個人化需求",
+      "description": "連接 OpenClaw、Ollama 或 Echo 供應商。自訂主題，設定深層連結觸發器，打造適合你工作流程的體驗。"
+    },
+    "getStarted": "開始使用"
+  },
+  "sessions": {
+    "title": "工作階段",
+    "newSession": "新建工作階段",
+    "editSession": "編輯工作階段",
+    "deleteSession": "刪除工作階段",
+    "sessionName": "工作階段名稱",
+    "defaultSession": "預設工作階段"
+  },
+  "favorites": {
+    "title": "收藏",
+    "noFavorites": "尚無收藏",
+    "addFavorite": "加入收藏",
+    "removeFavorite": "取消收藏"
+  },
+  "triggers": {
+    "title": "觸發器",
+    "newTrigger": "新建觸發器",
+    "editTrigger": "編輯觸發器",
+    "deleteTrigger": "刪除觸發器",
+    "noTriggers": "未設定觸發器"
+  },
+  "scheduler": {
+    "title": "排程器",
+    "cronJobs": "排程任務"
+  },
+  "gallery": {
+    "title": "元件庫"
+  },
+  "overview": {
+    "title": "總覽"
+  }
+}


### PR DESCRIPTION
Add full translation files for both Chinese variants covering all UI strings
including common actions, settings, onboarding, chat, sessions, and more.
Update i18n config to register both locales and improve device language
detection to match language-region codes (e.g., zh-CN, zh-TW).

https://claude.ai/code/session_01JsTi8e7ETiAJuSpY9WZpxZ