### PR TITLE
Add OpenRouter session support via session_id parameter

### DIFF
--- a/src/services/openrouter/OpenRouterChatProvider.ts
+++ b/src/services/openrouter/OpenRouterChatProvider.ts
@@ -44,6 +44,13 @@ interface OpenRouterStreamChunk {
 }
 
 /**
+ * Truncate a session key to fit within OpenRouter's 128-character session_id limit.
+ */
+function toSessionId(sessionKey: string): string {
+  return sessionKey.slice(0, 128)
+}
+
+/**
  * Chat provider for the OpenRouter API.
  *
  * OpenRouter provides a unified API for accessing many AI models
@@ -183,11 +190,14 @@ export class OpenRouterChatProvider implements ChatProvider {
       let fullResponse = ''
       let lastIndex = 0
 
+      const sessionId = toSessionId(params.sessionKey)
+
       xhr.open('POST', `${this.baseUrl}/api/v1/chat/completions`)
       xhr.setRequestHeader('Content-Type', 'application/json')
       xhr.setRequestHeader('Authorization', `Bearer ${this.apiKey}`)
       xhr.setRequestHeader('HTTP-Referer', 'https://github.com/lumiere-app')
       xhr.setRequestHeader('X-Title', 'Lumiere')
+      xhr.setRequestHeader('x-session-id', sessionId)
 
       xhr.onprogress = () => {
         const newData = xhr.responseText.substring(lastIndex)
@@ -252,6 +262,7 @@ export class OpenRouterChatProvider implements ChatProvider {
           max_tokens: API_CONFIG.OPENROUTER_MAX_TOKENS,
           messages: messages.map(this.formatMessageForApi),
           stream: true,
+          session_id: sessionId,
         }),
       )
     })


### PR DESCRIPTION
Send the app's session key as a session_id in both the request body
and x-session-id header on every chat completion request. This groups
related messages in a conversation together on OpenRouter's
observability dashboard (Broadcast). Session keys are truncated to
128 characters to comply with the OpenRouter API limit.

https://claude.ai/code/session_01LJRXmKcn7nEpbY6bTwSv6r