### PR TITLE
Add Kimi (Moonshot AI) chat provider

### DIFF
--- a/src/config/providerOptions.tsx
+++ b/src/config/providerOptions.tsx
@@ -30,6 +30,7 @@ export function getProviderIcon(type: ProviderType, color: string): React.ReactN
     gemini: GeminiIcon,
     'gemini-nano': null, // TODO: Add Gemini icon
     emergent: null, // TODO: Add Emergent icon
+    kimi: null, // TODO: Add Kimi icon
   }
 
   const Icon = icons[type]
@@ -64,6 +65,7 @@ export function getAllProviderOptions(color: string) {
         ]
       : []),
     { value: 'emergent', label: 'Emergent', icon: getProviderIcon('emergent', color) },
+    { value: 'kimi', label: 'Kimi', icon: getProviderIcon('kimi', color) },
     { value: 'echo', label: 'Echo Server', icon: getProviderIcon('echo', color) },
   ]
   return options
@@ -119,6 +121,11 @@ export function getBasicProviderOptions(color: string) {
       value: 'emergent' as ProviderType,
       label: 'Emergent',
       icon: getProviderIcon('emergent', color),
+    },
+    {
+      value: 'kimi' as ProviderType,
+      label: 'Kimi',
+      icon: getProviderIcon('kimi', color),
     },
     {
       value: 'echo' as ProviderType,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -21,6 +21,8 @@ export const DEFAULT_MODELS = {
   GEMINI: 'gemini-2.0-flash',
   /** Default Emergent model */
   EMERGENT: 'claude-sonnet-4-5',
+  /** Default Kimi (Moonshot AI) model */
+  KIMI: 'moonshot-v1-8k',
 } as const
 
 /**
@@ -37,6 +39,8 @@ export const API_CONFIG = {
   OPENROUTER_MAX_TOKENS: 4096,
   /** Default max tokens for Gemini API responses */
   GEMINI_MAX_TOKENS: 8192,
+  /** Default max tokens for Kimi API responses */
+  KIMI_MAX_TOKENS: 4096,
 } as const
 
 /**

--- a/src/services/kimi/KimiChatProvider.ts
+++ b/src/services/kimi/KimiChatProvider.ts
@@ -1,0 +1,320 @@
+import { API_CONFIG, DEFAULT_MODELS } from '../../constants'
+import {
+  ChatHistoryMessage,
+  ChatHistoryResponse,
+  ChatProvider,
+  ChatProviderEvent,
+  HealthStatus,
+  ProviderCapabilities,
+  ProviderConfig,
+  SendMessageParams,
+} from '../providers/types'
+
+interface KimiMessage {
+  role: 'user' | 'assistant' | 'system'
+  content: string | KimiContentPart[]
+}
+
+type KimiContentPart = KimiTextPart | KimiImagePart
+
+interface KimiTextPart {
+  type: 'text'
+  text: string
+}
+
+interface KimiImagePart {
+  type: 'image_url'
+  image_url: {
+    url: string
+  }
+}
+
+interface KimiStreamChunk {
+  id: string
+  choices: Array<{
+    delta: {
+      content?: string
+      role?: string
+    }
+    finish_reason: string | null
+  }>
+  error?: {
+    message: string
+  }
+}
+
+/**
+ * Chat provider for the Kimi (Moonshot AI) Chat Completions API.
+ *
+ * Uses the /v1/chat/completions endpoint with streaming support
+ * for real-time response delivery. Kimi uses an OpenAI-compatible
+ * API format (https://api.moonshot.cn).
+ */
+export class KimiChatProvider implements ChatProvider {
+  readonly capabilities: ProviderCapabilities = {
+    chat: true,
+    imageAttachments: true,
+    fileAttachments: false,
+    serverSessions: false,
+    persistentHistory: false,
+    scheduler: false,
+    gatewaySnapshot: false,
+  }
+
+  private baseUrl: string
+  private apiKey: string
+  private model: string
+  private connected = false
+  private connectionListeners: Array<(connected: boolean, reconnecting: boolean) => void> = []
+  private activeXhr: XMLHttpRequest | null = null
+
+  // In-memory conversation history keyed by session
+  private sessions: Map<string, KimiMessage[]> = new Map()
+
+  constructor(config: ProviderConfig) {
+    this.baseUrl = config.url.replace(/\/+$/, '')
+    this.apiKey = config.token
+    this.model = config.model || DEFAULT_MODELS.KIMI
+  }
+
+  async connect(): Promise<void> {
+    try {
+      const response = await fetch(`${this.baseUrl}/v1/models`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      })
+
+      if (!response.ok && response.status !== 401) {
+        throw new Error(`API returned status ${response.status}`)
+      }
+
+      this.connected = true
+      this.notifyConnectionState(true, false)
+    } catch {
+      this.connected = false
+      this.notifyConnectionState(false, false)
+      throw new Error('Cannot connect to Kimi API. Check your API key and endpoint.')
+    }
+  }
+
+  disconnect(): void {
+    if (this.activeXhr) {
+      this.activeXhr.abort()
+      this.activeXhr = null
+    }
+    this.connected = false
+    this.notifyConnectionState(false, false)
+  }
+
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  onConnectionStateChange(
+    listener: (connected: boolean, reconnecting: boolean) => void,
+  ): () => void {
+    this.connectionListeners.push(listener)
+    return () => {
+      this.connectionListeners = this.connectionListeners.filter((l) => l !== listener)
+    }
+  }
+
+  private notifyConnectionState(connected: boolean, reconnecting: boolean) {
+    this.connectionListeners.forEach((l) => l(connected, reconnecting))
+  }
+
+  private getSessionMessages(sessionKey: string): KimiMessage[] {
+    if (!this.sessions.has(sessionKey)) {
+      this.sessions.set(sessionKey, [])
+    }
+    return this.sessions.get(sessionKey)!
+  }
+
+  async sendMessage(
+    params: SendMessageParams,
+    onEvent: (event: ChatProviderEvent) => void,
+  ): Promise<void> {
+    const messages = this.getSessionMessages(params.sessionKey)
+
+    // Build the user message content
+    const contentParts: KimiContentPart[] = []
+
+    if (params.message) {
+      contentParts.push({ type: 'text', text: params.message })
+    }
+
+    // Add image attachments if present
+    if (params.attachments?.length) {
+      for (const attachment of params.attachments) {
+        if (attachment.type === 'image' && attachment.data) {
+          const mimeType = attachment.mimeType || 'image/png'
+          contentParts.push({
+            type: 'image_url',
+            image_url: {
+              url: `data:${mimeType};base64,${attachment.data}`,
+            },
+          })
+        }
+      }
+    }
+
+    const userMsg: KimiMessage = {
+      role: 'user',
+      content:
+        contentParts.length === 1 && contentParts[0].type === 'text'
+          ? contentParts[0].text
+          : contentParts,
+    }
+
+    messages.push(userMsg)
+
+    onEvent({ type: 'lifecycle', phase: 'start' })
+
+    // Use XMLHttpRequest for streaming — React Native's fetch does not
+    // support response.body ReadableStream, so XHR with onprogress is
+    // the reliable way to receive incremental SSE data.
+    return new Promise<void>((resolve, reject) => {
+      const xhr = new XMLHttpRequest()
+      this.activeXhr = xhr
+
+      let fullResponse = ''
+      let lastIndex = 0
+
+      xhr.open('POST', `${this.baseUrl}/v1/chat/completions`)
+      xhr.setRequestHeader('Content-Type', 'application/json')
+      xhr.setRequestHeader('Authorization', `Bearer ${this.apiKey}`)
+
+      xhr.onprogress = () => {
+        const newData = xhr.responseText.substring(lastIndex)
+        lastIndex = xhr.responseText.length
+
+        const lines = newData.split('\n')
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            const data = line.slice(6).trim()
+            if (data === '[DONE]') continue
+
+            try {
+              const chunk: KimiStreamChunk = JSON.parse(data)
+
+              if (chunk.error) {
+                reject(new Error(chunk.error.message || 'Stream error'))
+                xhr.abort()
+                return
+              }
+
+              const delta = chunk.choices?.[0]?.delta?.content
+              if (delta) {
+                fullResponse += delta
+                onEvent({ type: 'delta', delta })
+              }
+            } catch {
+              // Ignore JSON parse errors from partial chunks
+            }
+          }
+        }
+      }
+
+      xhr.onload = () => {
+        this.activeXhr = null
+        if (xhr.status >= 200 && xhr.status < 300) {
+          if (fullResponse) {
+            messages.push({ role: 'assistant', content: fullResponse })
+          }
+          onEvent({ type: 'lifecycle', phase: 'end' })
+          resolve()
+        } else {
+          onEvent({ type: 'lifecycle', phase: 'end' })
+          reject(new Error(`API error: ${xhr.status} - ${xhr.responseText}`))
+        }
+      }
+
+      xhr.onerror = () => {
+        this.activeXhr = null
+        onEvent({ type: 'lifecycle', phase: 'end' })
+        reject(new Error('Network error'))
+      }
+
+      xhr.onabort = () => {
+        this.activeXhr = null
+        onEvent({ type: 'lifecycle', phase: 'end' })
+        resolve()
+      }
+
+      xhr.send(
+        JSON.stringify({
+          model: this.model,
+          max_tokens: API_CONFIG.KIMI_MAX_TOKENS,
+          messages: messages.map(this.formatMessageForApi),
+          stream: true,
+        }),
+      )
+    })
+  }
+
+  private formatMessageForApi(msg: KimiMessage): { role: string; content: unknown } {
+    return {
+      role: msg.role,
+      content: msg.content,
+    }
+  }
+
+  async getChatHistory(sessionKey: string, limit?: number): Promise<ChatHistoryResponse> {
+    const messages = this.getSessionMessages(sessionKey)
+    const sliced = limit ? messages.slice(-limit) : messages
+
+    const historyMessages: ChatHistoryMessage[] = sliced
+      .filter(
+        (m): m is KimiMessage & { role: 'user' | 'assistant' } =>
+          m.role === 'user' || m.role === 'assistant',
+      )
+      .map((m, i) => ({
+        role: m.role,
+        content: [{ type: 'text', text: this.extractTextContent(m.content) }],
+        timestamp: Date.now() - (sliced.length - i) * 1000,
+      }))
+
+    return { messages: historyMessages }
+  }
+
+  private extractTextContent(content: string | KimiContentPart[]): string {
+    if (typeof content === 'string') {
+      return content
+    }
+    const textParts = content.filter((p): p is KimiTextPart => p.type === 'text' && !!p.text)
+    return textParts.map((p) => p.text).join('\n')
+  }
+
+  async resetSession(sessionKey: string): Promise<void> {
+    this.sessions.delete(sessionKey)
+  }
+
+  async listSessions(): Promise<unknown> {
+    return {
+      sessions: Array.from(this.sessions.keys()).map((key) => ({
+        key,
+        messageCount: this.sessions.get(key)?.length ?? 0,
+      })),
+    }
+  }
+
+  async getHealth(): Promise<HealthStatus> {
+    try {
+      const response = await fetch(`${this.baseUrl}/v1/models`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      })
+
+      if (response.ok) {
+        return { status: 'healthy' }
+      }
+      return { status: 'degraded' }
+    } catch {
+      return { status: 'unhealthy' }
+    }
+  }
+}

--- a/src/services/kimi/index.ts
+++ b/src/services/kimi/index.ts
@@ -1,0 +1,1 @@
+export { KimiChatProvider } from './KimiChatProvider'

--- a/src/services/providers/createProvider.ts
+++ b/src/services/providers/createProvider.ts
@@ -4,6 +4,7 @@ import { EchoChatProvider } from '../echo/EchoChatProvider'
 import { EmergentChatProvider } from '../emergent/EmergentChatProvider'
 import { GeminiChatProvider } from '../gemini/GeminiChatProvider'
 import { GeminiNanoChatProvider } from '../gemini-nano/GeminiNanoChatProvider'
+import { KimiChatProvider } from '../kimi/KimiChatProvider'
 import { OllamaChatProvider } from '../ollama/OllamaChatProvider'
 import { OpenAIChatProvider } from '../openai/OpenAIChatProvider'
 import { OpenRouterChatProvider } from '../openrouter/OpenRouterChatProvider'
@@ -52,6 +53,9 @@ export function createChatProvider(config: ProviderConfig): ChatProvider {
       break
     case 'emergent':
       inner = new EmergentChatProvider(config)
+      break
+    case 'kimi':
+      inner = new KimiChatProvider(config)
       break
     default:
       throw new Error(`Unknown provider type: ${(config as ProviderConfig).type}`)

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -12,6 +12,7 @@ export type ProviderType =
   | 'gemini-nano'
   | 'gemini'
   | 'emergent'
+  | 'kimi'
 
 export interface ProviderConfig {
   type: ProviderType


### PR DESCRIPTION
Implements a new chat provider for Kimi using the OpenAI-compatible
Moonshot AI API (api.moonshot.cn). Supports streaming responses via
SSE, image attachments, and in-memory session history.

https://claude.ai/code/session_01DM2NJnZUe1mZDD63hT5787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kimi (Moonshot AI) as a new chat provider option
  * Kimi now available in provider selection with preconfigured default settings and token limits
  * Streaming support enabled for Kimi chat completions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->