### PR TITLE
Fix cron job scheduler screen overflow issues

### DIFF
--- a/app/scheduler.tsx
+++ b/app/scheduler.tsx
@@ -305,8 +305,10 @@ export default function SchedulerScreen() {
                   Agent: {job.agentId}
                 </Text>
                 <Text variant="caption" color="tertiary" style={{ marginTop: theme.spacing.xs }}>
-                  n/a {'\u2022'} next {formatDateTime(job.state?.nextRunAtMs ?? null)} {'\u2022'}{' '}
-                  last {job.state?.lastRunAtMs ? formatDateTime(job.state.lastRunAtMs) : 'n/a'}
+                  Next: {formatDateTime(job.state?.nextRunAtMs ?? null)}
+                </Text>
+                <Text variant="caption" color="tertiary">
+                  Last: {job.state?.lastRunAtMs ? formatDateTime(job.state.lastRunAtMs) : 'n/a'}
                 </Text>
 
                 <View style={styles.badgeRow}>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -51,12 +51,14 @@ export function Badge({ label, variant = 'default', style, ...props }: BadgeProp
       borderWidth: 1,
       borderColor: colors.text + '30',
       alignSelf: 'flex-start',
+      maxWidth: '100%',
     },
     text: {
       fontSize: theme.typography.fontSize.xs,
       fontWeight: theme.typography.fontWeight.semibold,
       color: colors.text,
       fontFamily: theme.typography.fontFamily.monospace,
+      flexShrink: 1,
     },
   })
 

--- a/src/components/ui/StatCard.tsx
+++ b/src/components/ui/StatCard.tsx
@@ -57,7 +57,9 @@ export function StatCard({
       {...props}
     >
       <Text style={styles.label}>{label}</Text>
-      <Text style={styles.value}>{value}</Text>
+      <Text style={styles.value} numberOfLines={1} adjustsFontSizeToFit>
+        {value}
+      </Text>
       {description && <Text style={styles.description}>{description}</Text>}
     </View>
   )


### PR DESCRIPTION
- StatCard: Add adjustsFontSizeToFit to prevent long datetime values
  from overflowing at fontSize 32
- Scheduler: Split combined datetime caption into separate Next/Last
  lines to prevent horizontal overflow
- Badge: Add maxWidth and flexShrink to prevent long labels (e.g.
  agentId) from overflowing their row

https://claude.ai/code/session_01XbsDEtaXkUTjC6ZCiynEob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved scheduler display by separating Next and Last run timestamps onto individual lines for enhanced readability.
  * Enhanced Badge component with width constraints and improved text wrapping for better layout stability.
  * Optimized StatCard value display with automatic text scaling to fit single-line constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->