### PR TITLE
Add URL embed preview for detected links in chat messages

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react-native'
 import Markdown from 'react-native-markdown-display'
 
+import { useUrlMetadata } from '../../hooks/useUrlMetadata'
 import {
   clearMessagesAtom,
   currentSessionKeyAtom,
@@ -28,6 +29,7 @@ import {
 import { useTheme } from '../../theme'
 import { ChatIntent, extractIntents, intentIcon, stripIntents } from '../../utils/chatIntents'
 import { logger } from '../../utils/logger'
+import { LinkPreview } from './LinkPreview'
 
 const chatLogger = logger.create('ChatMessage')
 
@@ -411,6 +413,9 @@ export function ChatMessage({ message }: ChatMessageProps) {
     return linkifyText(text)
   }, [message.text, intents])
 
+  // Fetch URL embed previews for agent messages
+  const { metadata: urlPreviews } = useUrlMetadata(message.text, !!message.streaming, isUser)
+
   return (
     <View
       style={[styles.container, isUser ? styles.userContainer : styles.agentContainer]}
@@ -448,6 +453,13 @@ export function ChatMessage({ message }: ChatMessageProps) {
           <Text style={styles.streamingIndicator} selectable={true}>
             ...
           </Text>
+        )}
+        {urlPreviews.length > 0 && (
+          <View style={styles.linkPreviews}>
+            {urlPreviews.map((meta) => (
+              <LinkPreview key={meta.url} metadata={meta} />
+            ))}
+          </View>
         )}
       </View>
       {!message.streaming && intents.length > 0 && (
@@ -614,6 +626,10 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.text.secondary,
       fontSize: theme.typography.fontSize.sm,
       marginTop: theme.spacing.xs,
+    },
+    linkPreviews: {
+      marginTop: theme.spacing.sm,
+      gap: theme.spacing.xs,
     },
     attachmentContainer: {
       flexDirection: 'row',

--- a/src/components/chat/LinkPreview.tsx
+++ b/src/components/chat/LinkPreview.tsx
@@ -1,0 +1,146 @@
+import * as WebBrowser from 'expo-web-browser'
+import React, { useCallback, useMemo, useState } from 'react'
+import { Image, Platform, Pressable, StyleSheet, Text, View } from 'react-native'
+
+import { useTheme } from '../../theme'
+import { UrlMetadata } from '../../utils/urlMetadata'
+
+interface LinkPreviewProps {
+  metadata: UrlMetadata
+}
+
+export function LinkPreview({ metadata }: LinkPreviewProps) {
+  const { theme } = useTheme()
+  const styles = useMemo(() => createStyles(theme), [theme])
+  const [imageError, setImageError] = useState(false)
+  const [faviconError, setFaviconError] = useState(false)
+
+  const handlePress = useCallback(async () => {
+    try {
+      await WebBrowser.openBrowserAsync(metadata.url, {
+        presentationStyle: WebBrowser.WebBrowserPresentationStyle.PAGE_SHEET,
+        controlsColor: theme.colors.primary,
+      })
+    } catch {
+      // Silently fail
+    }
+  }, [metadata.url, theme.colors.primary])
+
+  const showImage = metadata.image && !imageError
+  const showFavicon = metadata.favicon && !faviconError && !showImage
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.container, pressed && styles.pressed]}
+      onPress={handlePress}
+      accessibilityRole="link"
+      accessibilityLabel={`Link preview: ${metadata.title ?? metadata.hostname}`}
+    >
+      {showImage && (
+        <Image
+          source={{ uri: metadata.image! }}
+          style={styles.thumbnail}
+          resizeMode="cover"
+          onError={() => setImageError(true)}
+          accessibilityLabel="Link thumbnail"
+        />
+      )}
+      <View style={styles.content}>
+        <View style={styles.header}>
+          {showFavicon && (
+            <Image
+              source={{ uri: metadata.favicon! }}
+              style={styles.favicon}
+              resizeMode="contain"
+              onError={() => setFaviconError(true)}
+            />
+          )}
+          <Text style={styles.hostname} numberOfLines={1}>
+            {metadata.hostname}
+          </Text>
+        </View>
+        {metadata.title && (
+          <Text style={styles.title} numberOfLines={2}>
+            {metadata.title}
+          </Text>
+        )}
+        {metadata.description && (
+          <Text style={styles.description} numberOfLines={2}>
+            {metadata.description}
+          </Text>
+        )}
+      </View>
+    </Pressable>
+  )
+}
+
+interface Theme {
+  colors: {
+    background: string
+    surface: string
+    border: string
+    text: { primary: string; secondary: string; tertiary: string }
+    primary: string
+    message: { agentText: string }
+  }
+  spacing: { xs: number; sm: number; md: number }
+  borderRadius: { sm: number; md: number }
+  typography: {
+    fontSize: { xs: number; sm: number; base: number }
+    fontWeight: { medium: '500'; semibold: '600' }
+  }
+  isDark: boolean
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: theme.borderRadius.md,
+      backgroundColor: theme.isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
+      overflow: 'hidden',
+      marginTop: theme.spacing.sm,
+      ...(Platform.OS === 'web' ? { cursor: 'pointer' as const } : {}),
+    },
+    pressed: {
+      opacity: 0.7,
+    },
+    thumbnail: {
+      width: 80,
+      height: 80,
+    },
+    content: {
+      flex: 1,
+      padding: theme.spacing.sm,
+      justifyContent: 'center',
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 2,
+    },
+    favicon: {
+      width: 14,
+      height: 14,
+      marginRight: theme.spacing.xs,
+      borderRadius: 2,
+    },
+    hostname: {
+      fontSize: theme.typography.fontSize.xs,
+      color: theme.colors.text.secondary,
+      flex: 1,
+    },
+    title: {
+      fontSize: theme.typography.fontSize.sm,
+      fontWeight: theme.typography.fontWeight.semibold,
+      color: theme.colors.message.agentText,
+      marginBottom: 2,
+    },
+    description: {
+      fontSize: theme.typography.fontSize.xs,
+      color: theme.colors.text.secondary,
+      lineHeight: theme.typography.fontSize.xs * 1.4,
+    },
+  })

--- a/src/hooks/useUrlMetadata.ts
+++ b/src/hooks/useUrlMetadata.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { extractUrls, fetchUrlMetadata, UrlMetadata } from '../utils/urlMetadata'
+
+/**
+ * Hook that extracts URLs from message text and fetches their Open Graph metadata.
+ * Only fetches for non-streaming agent messages. Results are cached per URL.
+ */
+export function useUrlMetadata(text: string, isStreaming: boolean, isUser: boolean) {
+  const [metadata, setMetadata] = useState<UrlMetadata[]>([])
+  const fetchedUrlsRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    // Don't fetch for user messages or while streaming
+    if (isUser || isStreaming) return
+
+    const urls = extractUrls(text)
+    if (urls.length === 0) return
+
+    // Only fetch URLs we haven't fetched yet
+    const newUrls = urls.filter((u) => !fetchedUrlsRef.current.has(u))
+    if (newUrls.length === 0) return
+
+    let cancelled = false
+
+    // Mark URLs as fetched immediately to avoid duplicate requests
+    for (const url of newUrls) {
+      fetchedUrlsRef.current.add(url)
+    }
+
+    const fetchAll = async () => {
+      const results = await Promise.all(newUrls.map((url) => fetchUrlMetadata(url)))
+      if (!cancelled) {
+        setMetadata((prev) => [...prev, ...results.filter((r) => r.title)])
+      }
+    }
+
+    fetchAll()
+
+    return () => {
+      cancelled = true
+    }
+  }, [text, isStreaming, isUser])
+
+  return { metadata }
+}

--- a/src/utils/urlMetadata.ts
+++ b/src/utils/urlMetadata.ts
@@ -1,0 +1,152 @@
+const URL_REGEX = /(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/g
+const MARKDOWN_LINK_REGEX = /\[([^\]]+)\]\(([^)]+)\)/g
+
+/**
+ * Extract plain URLs from text, ignoring URLs already inside markdown links.
+ */
+export function extractUrls(text: string): string[] {
+  // Remove markdown links so we don't double-count their URLs
+  const stripped = text.replace(MARKDOWN_LINK_REGEX, '')
+  const matches = stripped.match(URL_REGEX)
+  if (!matches) return []
+  // Deduplicate
+  return [...new Set(matches)]
+}
+
+export interface UrlMetadata {
+  url: string
+  title: string | null
+  description: string | null
+  image: string | null
+  favicon: string | null
+  hostname: string
+}
+
+function getHostname(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname
+  } catch {
+    return url
+  }
+}
+
+function extractMetaContent(html: string, property: string): string | null {
+  // Match both property="og:..." and name="og:..." variants
+  const patterns = [
+    new RegExp(`<meta[^>]+(?:property|name)=["']${property}["'][^>]+content=["']([^"']+)["']`, 'i'),
+    new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+(?:property|name)=["']${property}["']`, 'i'),
+  ]
+  for (const pattern of patterns) {
+    const match = html.match(pattern)
+    if (match?.[1]) return match[1]
+  }
+  return null
+}
+
+function extractTitle(html: string): string | null {
+  const match = html.match(/<title[^>]*>([^<]+)<\/title>/i)
+  return match?.[1]?.trim() ?? null
+}
+
+function getFaviconUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.origin}/favicon.ico`
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Fetch Open Graph / meta information for a given URL.
+ * Returns metadata with title, description, image, and favicon.
+ */
+export async function fetchUrlMetadata(url: string): Promise<UrlMetadata> {
+  const hostname = getHostname(url)
+  const fallback: UrlMetadata = {
+    url,
+    title: null,
+    description: null,
+    image: null,
+    favicon: getFaviconUrl(url),
+    hostname,
+  }
+
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 8000)
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; LumiereBot/1.0)',
+        Accept: 'text/html',
+      },
+      signal: controller.signal,
+    })
+    clearTimeout(timeoutId)
+
+    if (!response.ok) return fallback
+
+    // Only read first 50KB to avoid loading huge pages
+    const reader = response.body?.getReader()
+    if (!reader) {
+      const text = await response.text()
+      return parseHtmlMetadata(text.substring(0, 50000), url, hostname)
+    }
+
+    let html = ''
+    const decoder = new TextDecoder()
+    while (html.length < 50000) {
+      const { done, value } = await reader.read()
+      if (done) break
+      html += decoder.decode(value, { stream: true })
+      // Stop once we've passed the </head> tag
+      if (html.includes('</head>')) break
+    }
+    reader.cancel()
+
+    return parseHtmlMetadata(html, url, hostname)
+  } catch {
+    return fallback
+  }
+}
+
+function parseHtmlMetadata(html: string, url: string, hostname: string): UrlMetadata {
+  const ogTitle = extractMetaContent(html, 'og:title')
+  const ogDescription =
+    extractMetaContent(html, 'og:description') ?? extractMetaContent(html, 'description')
+  const ogImage = extractMetaContent(html, 'og:image')
+  const title = ogTitle ?? extractTitle(html)
+
+  // Resolve relative image URLs
+  let image = ogImage
+  if (image && !image.startsWith('http')) {
+    try {
+      image = new URL(image, url).href
+    } catch {
+      image = null
+    }
+  }
+
+  return {
+    url,
+    title: title ? decodeHtmlEntities(title) : null,
+    description: ogDescription ? decodeHtmlEntities(ogDescription) : null,
+    image,
+    favicon: getFaviconUrl(url),
+    hostname,
+  }
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, '/')
+}


### PR DESCRIPTION
When a URL is detected in agent responses, a compact preview card is
displayed showing the page title, description, thumbnail (from Open
Graph tags), and favicon. This fetches metadata client-side by parsing
HTML head content, only for non-streaming agent messages.

https://claude.ai/code/session_018NEnVdgzHiPNewqMA711AA