### PR TITLE
Add missing settings.contribute translations for ja, zh-CN, zh-TW

### DIFF
--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -47,7 +47,8 @@
     "language": "言語",
     "backupRestore": "バックアップと復元",
     "backupServers": "サーバーをバックアップ",
-    "restoreServers": "サーバーを復元"
+    "restoreServers": "サーバーを復元",
+    "contribute": "コントリビュート"
   },
   "home": {
     "connectionError": "接続エラー",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -47,7 +47,8 @@
     "language": "语言",
     "backupRestore": "备份与恢复",
     "backupServers": "备份服务器",
-    "restoreServers": "恢复服务器"
+    "restoreServers": "恢复服务器",
+    "contribute": "贡献"
   },
   "home": {
     "connectionError": "连接错误",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -47,7 +47,8 @@
     "language": "語言",
     "backupRestore": "備份與還原",
     "backupServers": "備份伺服器",
-    "restoreServers": "還原伺服器"
+    "restoreServers": "還原伺服器",
+    "contribute": "貢獻"
   },
   "home": {
     "connectionError": "連線錯誤",


### PR DESCRIPTION
The settings.contribute key existed in en, es, and fr locale files but
was missing from the Japanese, Simplified Chinese, and Traditional
Chinese translations.

https://claude.ai/code/session_01ADxUHNGSvm9NiQQywuBTXC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Contribute" option localization support for Japanese, Simplified Chinese, and Traditional Chinese languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->