### PR TITLE
Add full attachment support to Molt/OpenClaw chat provider

### DIFF
--- a/src/hooks/useMessageQueue.ts
+++ b/src/hooks/useMessageQueue.ts
@@ -78,8 +78,9 @@ export function useMessageQueue({
               type: 'image' as const,
               data: a.base64,
               mimeType: a.mimeType,
+              name: a.name,
             })
-          } else if (a.type === 'file' && a.uri) {
+          } else if ((a.type === 'file' || a.type === 'video') && a.uri) {
             try {
               const file = new ExpoFile(a.uri)
               const buffer = await file.arrayBuffer()
@@ -89,8 +90,9 @@ export function useMessageQueue({
                 binary += String.fromCharCode(bytes[i])
               }
               const base64 = btoa(binary)
+              const providerType = a.type === 'video' ? ('video' as const) : ('document' as const)
               converted.push({
-                type: 'document' as const,
+                type: providerType,
                 data: base64,
                 mimeType: a.mimeType || 'application/octet-stream',
                 name: a.name,

--- a/src/services/molt/types.ts
+++ b/src/services/molt/types.ts
@@ -130,10 +130,11 @@ export interface ChatHistoryParams {
 export type { ChatHistoryMessage } from '../providers/types'
 
 export interface Attachment {
-  type: 'image' | 'audio' | 'document'
+  type: 'image' | 'audio' | 'video' | 'document'
   url?: string
   data?: string
   mimeType?: string
+  fileName?: string
 }
 
 // Agent params

--- a/src/services/providers/MoltChatProvider.ts
+++ b/src/services/providers/MoltChatProvider.ts
@@ -20,7 +20,7 @@ export class MoltChatProvider implements ChatProvider {
   readonly capabilities: ProviderCapabilities = {
     chat: true,
     imageAttachments: true,
-    fileAttachments: false,
+    fileAttachments: true,
     serverSessions: true,
     persistentHistory: true,
     scheduler: true,
@@ -69,8 +69,9 @@ export class MoltChatProvider implements ChatProvider {
       sessionKey: params.sessionKey,
       attachments: params.attachments?.map((a) => ({
         type: a.type,
-        data: a.data,
+        content: a.data,
         mimeType: a.mimeType,
+        fileName: a.name,
       })),
     }
 

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -38,7 +38,7 @@ export interface SendMessageParams {
 }
 
 export interface ProviderAttachment {
-  type: 'image' | 'document'
+  type: 'image' | 'document' | 'audio' | 'video'
   data?: string // base64
   mimeType?: string
   name?: string


### PR DESCRIPTION
Enable file, video, and audio attachments for the OpenClaw (Molt) provider
by aligning with OpenClaw's ChatAttachment format (content/fileName fields).
Previously only image attachments were supported.

- Add 'audio' and 'video' to ProviderAttachment type union
- Add 'video' type and 'fileName' field to Molt Attachment type
- Enable fileAttachments capability in MoltChatProvider
- Map attachments to OpenClaw format (content instead of data, fileName)
- Handle video attachments in useMessageQueue (read from URI as base64)
- Pass attachment name through for image attachments

https://claude.ai/code/session_01VSFC7dt7sank6A1fFBbyZd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File attachments are now enabled in the chat provider.
  * Added support for video and audio file attachments.
  * Attachment file names are now captured and included with uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->