### PR TITLE
Add thinking/reasoning support to OpenClaw as a server capability

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -48,6 +48,7 @@ export interface Message {
   timestamp: Date
   streaming?: boolean
   attachments?: MessageAttachment[]
+  thinking?: string
 }
 
 interface ChatMessageProps {
@@ -86,6 +87,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
   const isUser = message.sender === 'user'
   const [copied, setCopied] = useState(false)
   const [intentCopied, setIntentCopied] = useState(false)
+  const [thinkingExpanded, setThinkingExpanded] = useState(false)
   const [favorites, setFavorites] = useAtom(favoritesAtom)
   const setCurrentSessionKey = useSetAtom(currentSessionKeyAtom)
   const setSessionAliases = useSetAtom(sessionAliasesAtom)
@@ -424,6 +426,31 @@ export function ChatMessage({ message }: ChatMessageProps) {
       accessibilityRole="text"
     >
       <View style={[styles.bubble, isUser ? styles.userBubble : styles.agentBubble]}>
+        {message.thinking && (
+          <View style={styles.thinkingContainer}>
+            <TouchableOpacity
+              onPress={() => setThinkingExpanded((prev) => !prev)}
+              style={styles.thinkingHeader}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel={thinkingExpanded ? 'Collapse thinking' : 'Expand thinking'}
+            >
+              <Ionicons
+                name={thinkingExpanded ? 'chevron-down' : 'chevron-forward'}
+                size={16}
+                color={theme.colors.text.secondary}
+              />
+              <Text style={styles.thinkingLabel}>
+                {message.streaming ? 'Thinking...' : 'Thinking'}
+              </Text>
+            </TouchableOpacity>
+            {thinkingExpanded && (
+              <Text style={styles.thinkingText} selectable={true}>
+                {message.thinking}
+              </Text>
+            )}
+          </View>
+        )}
         {message.attachments && message.attachments.length > 0 && (
           <View style={styles.attachmentContainer}>
             {message.attachments.map((attachment, index) => (
@@ -581,6 +608,31 @@ const createStyles = (theme: Theme) =>
       borderRadius: 0,
       paddingHorizontal: 0,
       ...(Platform.OS === 'web' ? { userSelect: 'text' as const } : {}),
+    },
+    thinkingContainer: {
+      marginBottom: theme.spacing.sm,
+      borderRadius: theme.borderRadius.md,
+      backgroundColor: theme.isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
+      overflow: 'hidden',
+    },
+    thinkingHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.sm,
+    },
+    thinkingLabel: {
+      fontSize: theme.typography.fontSize.sm,
+      color: theme.colors.text.secondary,
+      fontWeight: theme.typography.fontWeight.medium,
+      marginLeft: theme.spacing.xs,
+    },
+    thinkingText: {
+      fontSize: theme.typography.fontSize.sm,
+      color: theme.colors.text.secondary,
+      lineHeight: theme.typography.fontSize.sm * 1.5,
+      paddingHorizontal: theme.spacing.md,
+      paddingBottom: theme.spacing.sm,
     },
     intentActions: {
       flexDirection: 'row',

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -63,6 +63,7 @@ export function ChatScreen({ providerConfig }: ChatScreenProps) {
   const glassAvailable = isLiquidGlassAvailable()
   const [messages, setMessages] = useState<Message[]>([])
   const [currentAgentMessage, setCurrentAgentMessage] = useState<string>('')
+  const [currentThinkingMessage, setCurrentThinkingMessage] = useState<string>('')
   const [currentSessionKey] = useAtom(currentSessionKeyAtom)
   const [clearMessagesTrigger] = useAtom(clearMessagesAtom)
   const [pendingTriggerMessage, setPendingTriggerMessage] = useAtom(pendingTriggerMessageAtom)
@@ -170,6 +171,7 @@ export function ChatScreen({ providerConfig }: ChatScreenProps) {
       hasScrolledOnLoadRef.current = false
       shouldAutoScrollRef.current = true
       setCurrentAgentMessage('')
+      setCurrentThinkingMessage('')
     }
   }, [providerConfig.serverId])
 
@@ -181,9 +183,11 @@ export function ChatScreen({ providerConfig }: ChatScreenProps) {
     currentSessionKey,
     onMessageAdd: (message) => setMessages((prev) => [...prev, message]),
     onAgentMessageUpdate: (text) => setCurrentAgentMessage(text),
+    onThinkingUpdate: (text) => setCurrentThinkingMessage(text),
     onAgentMessageComplete: (message) => {
       setMessages((prev) => [...prev, message])
       setCurrentAgentMessage('')
+      setCurrentThinkingMessage('')
     },
     onSendStart: () => {
       shouldAutoScrollRef.current = true
@@ -271,6 +275,7 @@ export function ChatScreen({ providerConfig }: ChatScreenProps) {
       hasCacheRef.current = false
       setMessages([])
       setCurrentAgentMessage('')
+      setCurrentThinkingMessage('')
       hasScrolledOnLoadRef.current = false
       loadChatHistory()
     }
@@ -517,7 +522,7 @@ export function ChatScreen({ providerConfig }: ChatScreenProps) {
 
   const allMessages = [
     ...messages,
-    ...(currentAgentMessage
+    ...(currentAgentMessage || currentThinkingMessage
       ? [
           {
             id: 'streaming',
@@ -525,6 +530,7 @@ export function ChatScreen({ providerConfig }: ChatScreenProps) {
             sender: 'agent' as const,
             timestamp: new Date(),
             streaming: true,
+            thinking: currentThinkingMessage || undefined,
           },
         ]
       : []),

--- a/src/hooks/__tests__/useMessageQueue.test.ts
+++ b/src/hooks/__tests__/useMessageQueue.test.ts
@@ -32,6 +32,7 @@ function createMocks() {
   >()
   const onMessageAdd = jest.fn()
   const onAgentMessageUpdate = jest.fn()
+  const onThinkingUpdate = jest.fn()
   const onAgentMessageComplete = jest.fn()
   const onSendStart = jest.fn()
 
@@ -40,6 +41,7 @@ function createMocks() {
     currentSessionKey: 'test-session',
     onMessageAdd,
     onAgentMessageUpdate,
+    onThinkingUpdate,
     onAgentMessageComplete,
     onSendStart,
   }

--- a/src/hooks/useChatProvider.ts
+++ b/src/hooks/useChatProvider.ts
@@ -23,6 +23,7 @@ const DEFAULT_CAPABILITIES: ProviderCapabilities = {
   persistentHistory: false,
   scheduler: false,
   gatewaySnapshot: false,
+  thinking: false,
 }
 
 export interface UseChatProviderResult {

--- a/src/services/apple-intelligence/AppleChatProvider.ts
+++ b/src/services/apple-intelligence/AppleChatProvider.ts
@@ -34,6 +34,7 @@ export class AppleChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private connected = false

--- a/src/services/claude/ClaudeChatProvider.ts
+++ b/src/services/claude/ClaudeChatProvider.ts
@@ -61,6 +61,7 @@ export class ClaudeChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private baseUrl: string

--- a/src/services/echo/EchoChatProvider.ts
+++ b/src/services/echo/EchoChatProvider.ts
@@ -24,6 +24,7 @@ export class EchoChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private connected = false

--- a/src/services/emergent/EmergentChatProvider.ts
+++ b/src/services/emergent/EmergentChatProvider.ts
@@ -58,6 +58,7 @@ export class EmergentChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private baseUrl: string

--- a/src/services/gemini-nano/GeminiNanoChatProvider.ts
+++ b/src/services/gemini-nano/GeminiNanoChatProvider.ts
@@ -34,6 +34,7 @@ export class GeminiNanoChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private connected = false

--- a/src/services/gemini/GeminiChatProvider.ts
+++ b/src/services/gemini/GeminiChatProvider.ts
@@ -53,6 +53,7 @@ export class GeminiChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private baseUrl: string

--- a/src/services/kimi/KimiChatProvider.ts
+++ b/src/services/kimi/KimiChatProvider.ts
@@ -59,6 +59,7 @@ export class KimiChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private baseUrl: string

--- a/src/services/molt/types.ts
+++ b/src/services/molt/types.ts
@@ -159,7 +159,7 @@ export type AgentEvent = {
   runId: string
   seq: number
   sessionKey: string
-  stream: 'assistant' | 'lifecycle' | 'tool'
+  stream: 'assistant' | 'lifecycle' | 'tool' | 'thinking'
   ts: number
 }
 

--- a/src/services/ollama/OllamaChatProvider.ts
+++ b/src/services/ollama/OllamaChatProvider.ts
@@ -32,6 +32,7 @@ export class OllamaChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private client: Ollama

--- a/src/services/openai/OpenAIChatProvider.ts
+++ b/src/services/openai/OpenAIChatProvider.ts
@@ -59,6 +59,7 @@ export class OpenAIChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private baseUrl: string

--- a/src/services/openrouter/OpenRouterChatProvider.ts
+++ b/src/services/openrouter/OpenRouterChatProvider.ts
@@ -66,6 +66,7 @@ export class OpenRouterChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   private baseUrl: string

--- a/src/services/providers/MoltChatProvider.ts
+++ b/src/services/providers/MoltChatProvider.ts
@@ -25,6 +25,7 @@ export class MoltChatProvider implements ChatProvider {
     persistentHistory: true,
     scheduler: true,
     gatewaySnapshot: true,
+    thinking: true,
   }
 
   private client: MoltGatewayClient
@@ -78,6 +79,8 @@ export class MoltChatProvider implements ChatProvider {
     await this.client.sendAgentRequest(agentParams, (event: AgentEvent) => {
       if (event.stream === 'assistant' && event.data.delta) {
         onEvent({ type: 'delta', delta: event.data.delta })
+      } else if (event.stream === 'thinking' && event.data.delta) {
+        onEvent({ type: 'thinking', delta: event.data.delta })
       } else if (event.stream === 'lifecycle') {
         onEvent({ type: 'lifecycle', phase: event.data.phase })
       }

--- a/src/services/providers/__tests__/CachedChatProvider.test.ts
+++ b/src/services/providers/__tests__/CachedChatProvider.test.ts
@@ -29,6 +29,7 @@ function createMockProvider(overrides: Partial<ChatProvider> = {}): ChatProvider
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    thinking: false,
   }
 
   return {

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -24,8 +24,8 @@ export interface ProviderConfig {
 }
 
 export interface ChatProviderEvent {
-  type: 'delta' | 'lifecycle'
-  /** Incremental text chunk (for type === 'delta') */
+  type: 'delta' | 'lifecycle' | 'thinking'
+  /** Incremental text chunk (for type === 'delta' or 'thinking') */
   delta?: string
   /** Lifecycle phase (for type === 'lifecycle') */
   phase?: 'start' | 'end'
@@ -80,6 +80,8 @@ export interface ProviderCapabilities {
   scheduler: boolean
   /** Gateway snapshot with presence & instance info */
   gatewaySnapshot: boolean
+  /** Extended thinking / reasoning traces from the model */
+  thinking: boolean
 }
 
 /**


### PR DESCRIPTION
Introduce end-to-end support for extended thinking traces from the
model. The server streams thinking deltas via a new 'thinking' stream
type on agent events, which are surfaced through the provider
abstraction and rendered in the chat UI as a collapsible block.

- Add `thinking` boolean to ProviderCapabilities (true for Molt/OpenClaw)
- Add `'thinking'` to ChatProviderEvent type and AgentEvent stream union
- Handle thinking stream events in MoltChatProvider
- Accumulate thinking text in useMessageQueue alongside assistant text
- Render a collapsible "Thinking" section in ChatMessage for messages
  that include thinking content
- Update all providers and tests with the new capability field

https://claude.ai/code/session_011sEBU1sQeKqMKa6bWDTJmh