### PR TITLE
Move server config section to the top of settings

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -208,6 +208,23 @@ export default function SettingsScreen() {
 
         <View style={styles.spacer} />
 
+        {/* Server Config - only available for OpenClaw (Molt) servers */}
+        {currentServer?.providerType === 'molt' && (
+          <Section title={t('settings.serverConfig')} showDivider>
+            <SettingRow
+              icon="grid-outline"
+              label={t('settings.overview')}
+              onPress={() => router.push('/overview')}
+            />
+            <SettingRow
+              icon="time-outline"
+              label={t('settings.cronJobs')}
+              onPress={() => router.push('/scheduler')}
+              showDivider={false}
+            />
+          </Section>
+        )}
+
         {/* Main settings group */}
         <Section showDivider>
           <SettingRow
@@ -272,23 +289,6 @@ export default function SettingsScreen() {
             showDivider={false}
           />
         </Section>
-
-        {/* Server Config - only available for OpenClaw (Molt) servers */}
-        {currentServer?.providerType === 'molt' && (
-          <Section title={t('settings.serverConfig')} showDivider>
-            <SettingRow
-              icon="grid-outline"
-              label={t('settings.overview')}
-              onPress={() => router.push('/overview')}
-            />
-            <SettingRow
-              icon="time-outline"
-              label={t('settings.cronJobs')}
-              onPress={() => router.push('/scheduler')}
-              showDivider={false}
-            />
-          </Section>
-        )}
 
         {/* Developer */}
         {__DEV__ && (


### PR DESCRIPTION
Repositions the conditional Server Config section (Overview and Cron Jobs
for Molt/OpenClaw servers) from below Backup & Restore to directly after
the server list, making it more prominent and easier to access.

https://claude.ai/code/session_01Cj9MCzuqSQ1bxRTZmWP2SE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated the Server Config section in the settings interface. This component previously appeared in two separate locations; it now displays once in a single location immediately following the spacer element. All conditional rendering behavior for the molt provider configuration remains unchanged, with no functional impact on existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->