### PR TITLE
Fix landing page mobile responsiveness for iPhone and small devices

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -891,7 +891,7 @@
             font-size: 0.85rem;
         }
 
-        /* Responsive */
+        /* Responsive - Tablet */
         @media (max-width: 1024px) {
             .features-grid {
                 grid-template-columns: repeat(2, 1fr);
@@ -907,68 +907,465 @@
             }
         }
 
+        /* Responsive - Mobile */
         @media (max-width: 768px) {
+            .container {
+                padding: 0 20px;
+            }
+
+            /* Header */
             .nav-links {
                 display: none;
+            }
+
+            header {
+                padding: 14px 0;
+            }
+
+            header.scrolled {
+                padding: 10px 0;
+            }
+
+            .logo-text {
+                font-size: 1.1rem;
+            }
+
+            .header-cta {
+                gap: 8px;
+            }
+
+            .btn-testflight-sm {
+                padding: 8px 14px;
+                font-size: 0.8rem;
+                border-radius: 8px;
+                gap: 6px;
+            }
+
+            .btn-testflight-sm svg {
+                width: 16px;
+                height: 16px;
+            }
+
+            .github-link {
+                padding: 8px 12px;
+                border-radius: 8px;
+                font-size: 0.8rem;
             }
 
             .github-link span {
                 display: none;
             }
 
+            .github-link svg {
+                width: 18px;
+                height: 18px;
+            }
+
+            /* Hero */
             .hero {
-                padding: 130px 0 60px;
+                padding: 110px 0 56px;
+            }
+
+            .hero-logo {
+                max-width: 80px;
+                margin-bottom: 20px;
+            }
+
+            .hero-badge {
+                font-size: 0.8rem;
+                padding: 6px 14px;
+                margin-bottom: 20px;
             }
 
             .hero h1 {
-                font-size: 2.5rem;
+                font-size: 2.25rem;
+                margin-bottom: 16px;
             }
 
             .hero p {
-                font-size: 1.05rem;
+                font-size: 1rem;
+                margin-bottom: 32px;
+                line-height: 1.6;
             }
 
             .hero-buttons {
                 flex-direction: column;
-                align-items: center;
+                align-items: stretch;
+                gap: 12px;
+                padding: 0 8px;
             }
 
             .btn-primary, .btn-secondary {
-                width: 100%;
-                max-width: 320px;
                 justify-content: center;
+                padding: 14px 24px;
+                font-size: 1rem;
+                border-radius: 12px;
+            }
+
+            .hero-subtext {
+                margin-top: 14px;
+            }
+
+            /* Providers */
+            .providers {
+                padding: 40px 0;
+            }
+
+            .providers-label {
+                font-size: 0.8rem;
+                margin-bottom: 20px;
+            }
+
+            .providers-grid {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 16px;
+                max-width: 360px;
+                margin: 0 auto;
+            }
+
+            .provider-item {
+                font-size: 0.9rem;
+                gap: 8px;
+            }
+
+            .provider-icon {
+                width: 32px;
+                height: 32px;
+                border-radius: 8px;
+                font-size: 1rem;
+            }
+
+            /* Features */
+            .features {
+                padding: 64px 0;
+            }
+
+            .section-header {
+                margin-bottom: 36px;
+            }
+
+            .section-label {
+                font-size: 0.8rem;
+                margin-bottom: 8px;
+            }
+
+            .section-header h2 {
+                font-size: 1.75rem;
+                margin-bottom: 12px;
+            }
+
+            .section-header p {
+                font-size: 1rem;
             }
 
             .features-grid {
                 grid-template-columns: 1fr;
+                gap: 14px;
             }
 
-            .section-header h2,
-            .highlight-content h2,
-            .testflight-box h2 {
-                font-size: 2rem;
+            .feature-card {
+                padding: 24px;
+                border-radius: 16px;
             }
 
-            .providers-grid {
-                gap: 24px;
+            .feature-icon {
+                width: 44px;
+                height: 44px;
+                border-radius: 12px;
+                margin-bottom: 14px;
+                font-size: 1.3rem;
+            }
+
+            .feature-icon svg {
+                width: 22px;
+                height: 22px;
+            }
+
+            .feature-card h3 {
+                font-size: 1.05rem;
+                margin-bottom: 6px;
+            }
+
+            .feature-card p {
+                font-size: 0.9rem;
+            }
+
+            /* Highlight */
+            .highlight {
+                padding: 64px 0;
+            }
+
+            .highlight-grid {
+                gap: 36px;
+            }
+
+            .highlight-content h2 {
+                font-size: 1.75rem;
+                margin-bottom: 14px;
+            }
+
+            .highlight-content p {
+                font-size: 1rem;
+                margin-bottom: 24px;
+            }
+
+            .highlight-list {
+                gap: 12px;
+            }
+
+            .highlight-list li {
+                font-size: 0.9rem;
+                gap: 12px;
+            }
+
+            .highlight-list .check {
+                width: 22px;
+                height: 22px;
+            }
+
+            .highlight-list .check svg {
+                width: 12px;
+                height: 12px;
+            }
+
+            .highlight-card {
+                padding: 24px;
+                border-radius: 18px;
+            }
+
+            .mock-msg {
+                padding: 12px 16px;
+                font-size: 0.85rem;
+                border-radius: 14px;
+            }
+
+            /* Themes */
+            .themes {
+                padding: 64px 0;
+            }
+
+            .theme-showcase {
+                gap: 10px;
+                margin-top: 32px;
+            }
+
+            .theme-pill {
+                padding: 10px 16px;
+                gap: 8px;
+            }
+
+            .theme-pill .dot {
+                width: 16px;
+                height: 16px;
+            }
+
+            .theme-pill .label {
+                font-size: 0.82rem;
+            }
+
+            /* TestFlight CTA */
+            .testflight {
+                padding: 64px 0;
             }
 
             .testflight-box {
-                padding: 48px 24px;
+                padding: 40px 20px;
+                border-radius: 22px;
+            }
+
+            .testflight-box h2 {
+                font-size: 1.75rem;
+                margin-bottom: 12px;
+            }
+
+            .testflight-box p {
+                font-size: 1rem;
+                margin-bottom: 28px;
+                line-height: 1.6;
+            }
+
+            .testflight-buttons {
+                flex-direction: column;
+                align-items: stretch;
+                gap: 12px;
+            }
+
+            .btn-testflight, .btn-github-cta {
+                justify-content: center;
+                padding: 16px 28px;
+                font-size: 1rem;
+                border-radius: 12px;
+            }
+
+            .testflight-note {
+                margin-top: 16px;
+            }
+
+            /* Open Source */
+            .open-source {
+                padding: 64px 0;
             }
 
             .open-source-grid {
                 grid-template-columns: 1fr;
+                gap: 14px;
+                margin-top: 32px;
+            }
+
+            .os-card {
+                padding: 28px 24px;
+                border-radius: 16px;
+            }
+
+            .os-card .os-icon {
+                width: 42px;
+                height: 42px;
+                margin-bottom: 12px;
+                border-radius: 12px;
+            }
+
+            .os-card h3 {
+                font-size: 1rem;
+            }
+
+            .os-card p {
+                font-size: 0.85rem;
+            }
+
+            /* Footer */
+            footer {
+                padding: 36px 0;
             }
 
             .footer-top {
                 flex-direction: column;
-                gap: 32px;
+                gap: 28px;
             }
 
             .footer-links-grid {
-                gap: 32px;
+                gap: 24px;
                 flex-wrap: wrap;
+                width: 100%;
+            }
+
+            .footer-col {
+                min-width: 100px;
+            }
+
+            .footer-col h4 {
+                margin-bottom: 10px;
+            }
+
+            .footer-col a {
+                font-size: 0.85rem;
+                padding: 2px 0;
+            }
+
+            .footer-bottom {
+                padding-top: 20px;
+            }
+
+            .footer-copy {
+                font-size: 0.8rem;
+            }
+        }
+
+        /* Responsive - Small phones (iPhone SE, etc.) */
+        @media (max-width: 390px) {
+            .container {
+                padding: 0 16px;
+            }
+
+            .logo {
+                height: 30px;
+            }
+
+            .logo-text {
+                font-size: 1rem;
+            }
+
+            .logo-group {
+                gap: 8px;
+            }
+
+            .btn-testflight-sm {
+                padding: 8px 10px;
+                font-size: 0.75rem;
+            }
+
+            .hero {
+                padding: 100px 0 48px;
+            }
+
+            .hero-logo {
+                max-width: 64px;
+                margin-bottom: 16px;
+            }
+
+            .hero h1 {
+                font-size: 1.85rem;
+            }
+
+            .hero p {
+                font-size: 0.9rem;
+                margin-bottom: 28px;
+            }
+
+            .hero-buttons {
+                padding: 0;
+            }
+
+            .btn-primary, .btn-secondary {
+                padding: 13px 20px;
+                font-size: 0.95rem;
+            }
+
+            .providers-grid {
+                max-width: 100%;
+                gap: 12px;
+            }
+
+            .section-header h2 {
+                font-size: 1.5rem;
+            }
+
+            .feature-card {
+                padding: 20px;
+            }
+
+            .highlight-content h2 {
+                font-size: 1.5rem;
+            }
+
+            .highlight-card {
+                padding: 20px;
+            }
+
+            .testflight-box {
+                padding: 32px 16px;
+                border-radius: 18px;
+            }
+
+            .testflight-box h2 {
+                font-size: 1.5rem;
+            }
+
+            .theme-pill {
+                padding: 8px 12px;
+            }
+
+            .theme-pill .label {
+                font-size: 0.78rem;
+            }
+
+            .theme-pill .dot {
+                width: 14px;
+                height: 14px;
+            }
+
+            .footer-links-grid {
+                gap: 20px;
             }
         }
 


### PR DESCRIPTION
Comprehensive mobile UX improvements:
- Header: compact CTA buttons, hide GitHub text label, reduce padding
- Hero: scale down logo/title/text for mobile, full-width stacked buttons
- Providers: switch to 2x2 grid layout on mobile for even alignment
- Features: reduce card padding, smaller icons, tighter grid gap
- Highlight: compact mock-chat card, smaller checkmarks and text
- Themes: smaller pills with reduced padding/gap
- TestFlight CTA: stacked buttons, reduced padding and text sizes
- Open Source: compact cards with smaller padding
- Footer: better column flow, smaller text, proper wrapping
- Add 390px breakpoint for iPhone SE and very small phones

https://claude.ai/code/session_01XNLJEGNeuX4faYU5ezYjoZ