### PR TITLE
Add session support for Apple Intelligence

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -72,12 +72,14 @@ Each provider declares its capabilities via `ProviderCapabilities`. These act as
 | ------------------- | ---------------------- | ---- | ------ | ------ | ------ | ---------- | ----- | ------ |
 | `chat`              | Basic chat messaging   | yes  | yes    | yes    | yes    | yes        | yes   | yes    |
 | `imageAttachments`  | Image upload support   | no   | yes    | no     | no     | no         | no    | no     |
-| `serverSessions`    | Server-side sessions   | yes  | no     | no     | no     | no         | no    | no     |
+| `serverSessions`    | Server-side sessions   | yes  | no     | no     | no     | no         | no\*  | no     |
 | `persistentHistory` | Remote history storage | yes  | no     | no     | no     | no         | no    | no     |
 | `scheduler`         | Cron job scheduling    | yes  | no     | no     | no     | no         | no    | no     |
 | `gatewaySnapshot`   | Health snapshots       | yes  | no     | no     | no     | no         | no    | no     |
 
 > Note: `CachedChatProvider` adds local caching to all providers regardless of their declared `persistentHistory` capability.
+>
+> \* Apple Intelligence does not have server-side sessions but supports local on-device sessions via the `CachedChatProvider` session index. Users can create, switch, and manage multiple sessions on iPad/foldable sidebar and the phone sessions screen.
 
 ## Molt Gateway Configuration
 


### PR DESCRIPTION
Enable multi-session management for the Apple Intelligence provider on
iPad/foldable sidebar layout. Previously, only the Molt provider supported
sessions in the tablet sidebar; all other providers were locked to a single
"agent:main" session.

Changes:
- Load sessions from local CachedChatProvider session index for Apple Intelligence
- Allow creating, switching, and listing multiple sessions on the sidebar
- Use default session key (agent:main:main) when switching to Apple servers
- Update documentation to reflect Apple Intelligence local session capability

https://claude.ai/code/session_019EucFWa1jAuJQSJuJCCEZc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for local on-device sessions for Apple Intelligence, enabling persistent session management without requiring server infrastructure.

* **Documentation**
  * Updated documentation clarifying that Apple Intelligence supports local on-device sessions through the CachedChatProvider, with guidance on session behavior across different device types including iPad, foldable devices, and phones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->