### PR TITLE
Treat images and videos as file attachments in OpenClaw provider

### DIFF
--- a/src/hooks/__tests__/useMessageQueue.test.ts
+++ b/src/hooks/__tests__/useMessageQueue.test.ts
@@ -219,7 +219,7 @@ describe('useMessageQueue', () => {
 
       expect(mocks.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          attachments: [{ type: 'document', data: 'abc123', mimeType: 'image/png' }],
+          attachments: [{ type: 'image', data: 'abc123', mimeType: 'image/png' }],
         }),
         expect.any(Function),
       )


### PR DESCRIPTION
All media attachments (images, videos) are now sent as 'document' type
to the Molt gateway, unifying handling with regular file attachments.
This ensures consistent file-based processing regardless of media type.

https://claude.ai/code/session_01DYGPqiRNwtQzV2erPD2G3W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized attachment handling to ensure consistent processing across all attachment types (images, videos, files) in provider communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->