### PR TITLE
Add skills RPC support to Molt gateway with teach/list/remove/update methods

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -102,6 +102,7 @@ function AppContent() {
       <Stack.Screen name="edit-session" options={modalOptions} />
       <Stack.Screen name="overview" options={modalOptions} />
       <Stack.Screen name="scheduler" options={modalOptions} />
+      <Stack.Screen name="skills" options={modalOptions} />
       <Stack.Screen name="gallery" options={modalOptions} />
       <Stack.Screen name="colors" options={modalOptions} />
       <Stack.Screen name="favorites" options={modalOptions} />

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -214,6 +214,11 @@ export default function SettingsScreen() {
               icon="time-outline"
               label={t('settings.cronJobs')}
               onPress={() => router.push('/scheduler')}
+            />
+            <SettingRow
+              icon="bulb-outline"
+              label={t('settings.skills')}
+              onPress={() => router.push('/skills')}
               showDivider={false}
             />
           </Section>

--- a/app/skills.tsx
+++ b/app/skills.tsx
@@ -1,0 +1,340 @@
+import { useRouter } from 'expo-router'
+import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Alert, ScrollView, StyleSheet, TextInput, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import { Badge, Button, Card, ScreenHeader, Section, StatCard, Text } from '../src/components/ui'
+import { useServers } from '../src/hooks/useServers'
+import { useMoltGateway } from '../src/services/molt'
+import { Skill } from '../src/services/molt/types'
+import { useTheme } from '../src/theme'
+import { logger } from '../src/utils/logger'
+
+const skillsLogger = logger.create('Skills')
+
+export default function SkillsScreen() {
+  const { theme } = useTheme()
+  const router = useRouter()
+  const { t } = useTranslation()
+  const { getProviderConfig, currentServerId, currentServer } = useServers()
+  const [config, setConfig] = useState<{ url: string; token: string } | null>(null)
+
+  const [skills, setSkills] = useState<Skill[]>([])
+  const [showTeachForm, setShowTeachForm] = useState(false)
+  const [newSkillName, setNewSkillName] = useState('')
+  const [newSkillDescription, setNewSkillDescription] = useState('')
+  const [newSkillContent, setNewSkillContent] = useState('')
+  const [teaching, setTeaching] = useState(false)
+
+  useEffect(() => {
+    const loadConfig = async () => {
+      const providerConfig = await getProviderConfig()
+      setConfig(providerConfig)
+    }
+    loadConfig()
+  }, [getProviderConfig, currentServerId])
+
+  const { connected, connect, listSkills, teachSkill, removeSkill } = useMoltGateway({
+    url: config?.url || '',
+    token: config?.token || '',
+  })
+
+  useEffect(() => {
+    if (config) {
+      connect()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config])
+
+  useEffect(() => {
+    if (connected) {
+      fetchSkills()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connected])
+
+  const fetchSkills = async () => {
+    try {
+      const result = await listSkills()
+      if (result?.skills) {
+        setSkills(result.skills)
+      }
+    } catch (err) {
+      skillsLogger.logError('Failed to fetch skills', err)
+    }
+  }
+
+  const handleRefresh = async () => {
+    await fetchSkills()
+  }
+
+  const handleTeachSkill = async () => {
+    if (!newSkillName.trim() || !newSkillDescription.trim() || !newSkillContent.trim()) {
+      Alert.alert(t('common.error'), t('skills.fillAllFields'))
+      return
+    }
+
+    setTeaching(true)
+    try {
+      await teachSkill({
+        name: newSkillName.trim(),
+        description: newSkillDescription.trim(),
+        content: newSkillContent.trim(),
+      })
+      setNewSkillName('')
+      setNewSkillDescription('')
+      setNewSkillContent('')
+      setShowTeachForm(false)
+      await fetchSkills()
+    } catch (err) {
+      skillsLogger.logError('Failed to teach skill', err)
+      Alert.alert(t('common.error'), t('skills.teachError'))
+    } finally {
+      setTeaching(false)
+    }
+  }
+
+  const handleRemoveSkill = async (skill: Skill) => {
+    Alert.alert(t('skills.removeSkill'), t('skills.removeConfirm', { name: skill.name }), [
+      { text: t('common.cancel'), style: 'cancel' },
+      {
+        text: t('common.delete'),
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await removeSkill(skill.name)
+            await fetchSkills()
+          } catch (err) {
+            skillsLogger.logError('Failed to remove skill', err)
+            Alert.alert(t('common.error'), t('skills.removeError'))
+          }
+        },
+      },
+    ])
+  }
+
+  const formatDateTime = (timestamp: number): string => {
+    const date = new Date(timestamp)
+    return date.toLocaleString('en-US', {
+      month: 'numeric',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    })
+  }
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    scrollContent: {
+      padding: theme.spacing.lg,
+    },
+    statsRow: {
+      flexDirection: 'row',
+      gap: theme.spacing.md,
+      marginBottom: theme.spacing.md,
+    },
+    formContainer: {
+      gap: theme.spacing.md,
+      marginBottom: theme.spacing.md,
+    },
+    input: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.borderRadius.md,
+      padding: theme.spacing.md,
+      color: theme.colors.text.primary,
+      fontSize: 14,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+    },
+    contentInput: {
+      backgroundColor: theme.colors.surface,
+      borderRadius: theme.borderRadius.md,
+      padding: theme.spacing.md,
+      color: theme.colors.text.primary,
+      fontSize: 14,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      minHeight: 120,
+      textAlignVertical: 'top',
+    },
+    formActions: {
+      flexDirection: 'row',
+      gap: theme.spacing.sm,
+    },
+    badgeRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.spacing.xs,
+      marginTop: theme.spacing.sm,
+    },
+    skillActions: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.spacing.sm,
+      marginTop: theme.spacing.md,
+    },
+  })
+
+  if (currentServer?.providerType !== 'molt') {
+    return (
+      <SafeAreaView style={styles.container}>
+        <ScreenHeader title={t('skills.title')} showBack />
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: theme.spacing.lg,
+          }}
+        >
+          <Text variant="heading2" style={{ marginBottom: theme.spacing.md }}>
+            {t('skills.openClawOnly')}
+          </Text>
+          <Text color="secondary" center style={{ marginBottom: theme.spacing.xl }}>
+            {t('skills.openClawOnlyDescription')}
+          </Text>
+          <Button title={t('home.goToSettings')} onPress={() => router.push('/settings')} />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  if (!config) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <ScreenHeader title={t('skills.title')} showBack />
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: theme.spacing.lg,
+          }}
+        >
+          <Text variant="heading2" style={{ marginBottom: theme.spacing.md }}>
+            {t('home.noServerConfigured')}
+          </Text>
+          <Text color="secondary" center style={{ marginBottom: theme.spacing.xl }}>
+            {t('home.noServerMessage')}
+          </Text>
+          <Button title={t('home.goToSettings')} onPress={() => router.push('/settings')} />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScreenHeader title={t('skills.title')} subtitle={t('skills.subtitle')} showBack />
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Section>
+          <View style={styles.statsRow}>
+            <StatCard label={t('skills.totalSkills')} value={skills.length} style={{ flex: 1 }} />
+          </View>
+
+          <View style={{ flexDirection: 'row', gap: theme.spacing.sm }}>
+            <Button title={t('common.retry')} variant="secondary" onPress={handleRefresh} />
+            <Button
+              title={showTeachForm ? t('common.cancel') : t('skills.teachNew')}
+              onPress={() => setShowTeachForm(!showTeachForm)}
+            />
+          </View>
+        </Section>
+
+        {showTeachForm && (
+          <Section title={t('skills.teachSkill')}>
+            <View style={styles.formContainer}>
+              <TextInput
+                style={styles.input}
+                placeholder={t('skills.namePlaceholder')}
+                placeholderTextColor={theme.colors.text.secondary}
+                value={newSkillName}
+                onChangeText={setNewSkillName}
+                autoCapitalize="none"
+              />
+              <TextInput
+                style={styles.input}
+                placeholder={t('skills.descriptionPlaceholder')}
+                placeholderTextColor={theme.colors.text.secondary}
+                value={newSkillDescription}
+                onChangeText={setNewSkillDescription}
+              />
+              <TextInput
+                style={styles.contentInput}
+                placeholder={t('skills.contentPlaceholder')}
+                placeholderTextColor={theme.colors.text.secondary}
+                value={newSkillContent}
+                onChangeText={setNewSkillContent}
+                multiline
+              />
+              <View style={styles.formActions}>
+                <Button
+                  title={teaching ? t('common.loading') : t('skills.teach')}
+                  onPress={handleTeachSkill}
+                  disabled={teaching}
+                />
+              </View>
+            </View>
+          </Section>
+        )}
+
+        <Section title={t('skills.skillsList')}>
+          <Text variant="bodySmall" color="secondary" style={{ marginBottom: theme.spacing.lg }}>
+            {t('skills.skillsListDescription')}
+          </Text>
+
+          {skills.length === 0 ? (
+            <Text color="secondary" center>
+              {t('skills.noSkills')}
+            </Text>
+          ) : (
+            skills.map((skill) => (
+              <Card key={skill.name} style={{ marginBottom: theme.spacing.md }}>
+                <Text variant="heading3" style={{ marginBottom: theme.spacing.xs }}>
+                  {skill.name}
+                </Text>
+                <Text variant="bodySmall" color="secondary">
+                  {skill.description}
+                </Text>
+                <Text
+                  variant="caption"
+                  color="tertiary"
+                  style={{ marginTop: theme.spacing.xs }}
+                  numberOfLines={3}
+                >
+                  {skill.content}
+                </Text>
+                <Text variant="caption" color="tertiary" style={{ marginTop: theme.spacing.xs }}>
+                  {t('skills.created')}: {formatDateTime(skill.createdAtMs)}
+                </Text>
+                <Text variant="caption" color="tertiary">
+                  {t('skills.updated')}: {formatDateTime(skill.updatedAtMs)}
+                </Text>
+
+                <View style={styles.badgeRow}>
+                  <Badge label={skill.name} />
+                </View>
+
+                <View style={styles.skillActions}>
+                  <Button
+                    title={t('common.delete')}
+                    variant="danger"
+                    size="sm"
+                    onPress={() => handleRemoveSkill(skill)}
+                  />
+                </View>
+              </Card>
+            ))
+          )}
+        </Section>
+      </ScrollView>
+    </SafeAreaView>
+  )
+}

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -162,6 +162,7 @@ export class NewChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   };
 
   async connect(): Promise<void> { /* ... */ }

--- a/src/hooks/useChatProvider.ts
+++ b/src/hooks/useChatProvider.ts
@@ -23,6 +23,7 @@ const DEFAULT_CAPABILITIES: ProviderCapabilities = {
   persistentHistory: false,
   scheduler: false,
   gatewaySnapshot: false,
+  skills: false,
 }
 
 export interface UseChatProviderResult {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -48,7 +48,8 @@
     "backupRestore": "Sicherung & Wiederherstellung",
     "backupServers": "Server sichern",
     "restoreServers": "Server wiederherstellen",
-    "contribute": "Mitwirken"
+    "contribute": "Mitwirken",
+    "skills": "Fähigkeiten"
   },
   "home": {
     "connectionError": "Verbindungsfehler",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "Doppelte Server wurden übersprungen",
     "replaceExisting": "Vorhandene Server ersetzen",
     "mergeWithExisting": "Mit vorhandenen Servern zusammenführen"
+  },
+  "skills": {
+    "title": "Fähigkeiten",
+    "subtitle": "Fähigkeiten für Ihren Agenten lehren und verwalten.",
+    "totalSkills": "FÄHIGKEITEN",
+    "teachNew": "Neue lehren",
+    "teachSkill": "Fähigkeit lehren",
+    "teach": "Lehren",
+    "skillsList": "Fähigkeiten",
+    "skillsListDescription": "Alle dem Agenten beigebrachten Fähigkeiten.",
+    "noSkills": "Keine Fähigkeiten konfiguriert",
+    "namePlaceholder": "Fähigkeitsname (z.B. zusammenfassen)",
+    "descriptionPlaceholder": "Kurze Beschreibung der Fähigkeit",
+    "contentPlaceholder": "Fähigkeitsinhalt oder Anweisungen...",
+    "fillAllFields": "Bitte füllen Sie alle Felder aus",
+    "teachError": "Fähigkeit konnte nicht gelehrt werden",
+    "removeSkill": "Fähigkeit entfernen",
+    "removeConfirm": "Möchten Sie die Fähigkeit \"{{name}}\" wirklich entfernen?",
+    "removeError": "Fähigkeit konnte nicht entfernt werden",
+    "created": "Erstellt",
+    "updated": "Aktualisiert",
+    "openClawOnly": "Nur OpenClaw",
+    "openClawOnlyDescription": "Fähigkeiten sind nur für OpenClaw-Server verfügbar."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,6 +28,7 @@
     "overview": "Overview",
     "serverConfig": "Server Config",
     "cronJobs": "Cron Jobs",
+    "skills": "Skills",
     "componentGallery": "Component Gallery",
     "logout": "Logout",
     "logoutConfirmTitle": "Logout",
@@ -148,6 +149,29 @@
   "scheduler": {
     "title": "Scheduler",
     "cronJobs": "Cron Jobs"
+  },
+  "skills": {
+    "title": "Skills",
+    "subtitle": "Teach and manage skills for your agent.",
+    "totalSkills": "SKILLS",
+    "teachNew": "Teach New",
+    "teachSkill": "Teach Skill",
+    "teach": "Teach",
+    "skillsList": "Skills",
+    "skillsListDescription": "All skills taught to the agent.",
+    "noSkills": "No skills configured",
+    "namePlaceholder": "Skill name (e.g. summarize)",
+    "descriptionPlaceholder": "Short description of the skill",
+    "contentPlaceholder": "Skill content or instructions...",
+    "fillAllFields": "Please fill in all fields",
+    "teachError": "Failed to teach skill",
+    "removeSkill": "Remove Skill",
+    "removeConfirm": "Are you sure you want to remove the skill \"{{name}}\"?",
+    "removeError": "Failed to remove skill",
+    "created": "Created",
+    "updated": "Updated",
+    "openClawOnly": "OpenClaw Only",
+    "openClawOnlyDescription": "Skills are only available for OpenClaw servers."
   },
   "gallery": {
     "title": "Gallery"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -48,7 +48,8 @@
     "backupRestore": "Respaldo y Restauración",
     "backupServers": "Respaldar Servidores",
     "restoreServers": "Restaurar Servidores",
-    "contribute": "Contribuir"
+    "contribute": "Contribuir",
+    "skills": "Habilidades"
   },
   "home": {
     "connectionError": "Error de Conexión",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "Los servidores duplicados fueron omitidos",
     "replaceExisting": "Reemplazar servidores existentes",
     "mergeWithExisting": "Combinar con servidores existentes"
+  },
+  "skills": {
+    "title": "Habilidades",
+    "subtitle": "Enseña y gestiona habilidades para tu agente.",
+    "totalSkills": "HABILIDADES",
+    "teachNew": "Enseñar Nueva",
+    "teachSkill": "Enseñar Habilidad",
+    "teach": "Enseñar",
+    "skillsList": "Habilidades",
+    "skillsListDescription": "Todas las habilidades enseñadas al agente.",
+    "noSkills": "No hay habilidades configuradas",
+    "namePlaceholder": "Nombre de la habilidad (ej. resumir)",
+    "descriptionPlaceholder": "Descripción breve de la habilidad",
+    "contentPlaceholder": "Contenido o instrucciones de la habilidad...",
+    "fillAllFields": "Por favor, completa todos los campos",
+    "teachError": "Error al enseñar la habilidad",
+    "removeSkill": "Eliminar Habilidad",
+    "removeConfirm": "¿Estás seguro de que deseas eliminar la habilidad \"{{name}}\"?",
+    "removeError": "Error al eliminar la habilidad",
+    "created": "Creada",
+    "updated": "Actualizada",
+    "openClawOnly": "Solo OpenClaw",
+    "openClawOnlyDescription": "Las habilidades solo están disponibles para servidores OpenClaw."
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -48,7 +48,8 @@
     "backupRestore": "Sauvegarde et Restauration",
     "backupServers": "Sauvegarder les Serveurs",
     "restoreServers": "Restaurer les Serveurs",
-    "contribute": "Contribuer"
+    "contribute": "Contribuer",
+    "skills": "Compétences"
   },
   "home": {
     "connectionError": "Erreur de connexion",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "Les serveurs en double ont été ignorés",
     "replaceExisting": "Remplacer les serveurs existants",
     "mergeWithExisting": "Fusionner avec les serveurs existants"
+  },
+  "skills": {
+    "title": "Compétences",
+    "subtitle": "Enseignez et gérez les compétences de votre agent.",
+    "totalSkills": "COMPÉTENCES",
+    "teachNew": "Enseigner",
+    "teachSkill": "Enseigner une compétence",
+    "teach": "Enseigner",
+    "skillsList": "Compétences",
+    "skillsListDescription": "Toutes les compétences enseignées à l'agent.",
+    "noSkills": "Aucune compétence configurée",
+    "namePlaceholder": "Nom de la compétence (ex. résumer)",
+    "descriptionPlaceholder": "Brève description de la compétence",
+    "contentPlaceholder": "Contenu ou instructions de la compétence...",
+    "fillAllFields": "Veuillez remplir tous les champs",
+    "teachError": "Échec de l'enseignement de la compétence",
+    "removeSkill": "Supprimer la compétence",
+    "removeConfirm": "Êtes-vous sûr de vouloir supprimer la compétence \"{{name}}\" ?",
+    "removeError": "Échec de la suppression de la compétence",
+    "created": "Créée",
+    "updated": "Mise à jour",
+    "openClawOnly": "OpenClaw uniquement",
+    "openClawOnlyDescription": "Les compétences ne sont disponibles que pour les serveurs OpenClaw."
   }
 }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -48,7 +48,8 @@
     "backupRestore": "बैकअप और रिस्टोर",
     "backupServers": "सर्वर बैकअप",
     "restoreServers": "सर्वर रिस्टोर",
-    "contribute": "योगदान करें"
+    "contribute": "योगदान करें",
+    "skills": "कौशल"
   },
   "home": {
     "connectionError": "कनेक्शन त्रुटि",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "डुप्लिकेट सर्वर छोड़ दिए गए",
     "replaceExisting": "मौजूदा सर्वर बदलें",
     "mergeWithExisting": "मौजूदा सर्वर के साथ मर्ज करें"
+  },
+  "skills": {
+    "title": "कौशल",
+    "subtitle": "अपने एजेंट के लिए कौशल सिखाएं और प्रबंधित करें।",
+    "totalSkills": "कौशल",
+    "teachNew": "नया सिखाएं",
+    "teachSkill": "कौशल सिखाएं",
+    "teach": "सिखाएं",
+    "skillsList": "कौशल",
+    "skillsListDescription": "एजेंट को सिखाए गए सभी कौशल।",
+    "noSkills": "कोई कौशल कॉन्फ़िगर नहीं किया गया",
+    "namePlaceholder": "कौशल का नाम (जैसे सारांश)",
+    "descriptionPlaceholder": "कौशल का संक्षिप्त विवरण",
+    "contentPlaceholder": "कौशल सामग्री या निर्देश...",
+    "fillAllFields": "कृपया सभी फ़ील्ड भरें",
+    "teachError": "कौशल सिखाने में विफल",
+    "removeSkill": "कौशल हटाएं",
+    "removeConfirm": "क्या आप वाकई कौशल \"{{name}}\" को हटाना चाहते हैं?",
+    "removeError": "कौशल हटाने में विफल",
+    "created": "बनाया गया",
+    "updated": "अपडेट किया गया",
+    "openClawOnly": "केवल OpenClaw",
+    "openClawOnlyDescription": "कौशल केवल OpenClaw सर्वर के लिए उपलब्ध हैं।"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -48,7 +48,8 @@
     "backupRestore": "バックアップと復元",
     "backupServers": "サーバーをバックアップ",
     "restoreServers": "サーバーを復元",
-    "contribute": "コントリビュート"
+    "contribute": "コントリビュート",
+    "skills": "スキル"
   },
   "home": {
     "connectionError": "接続エラー",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "重複するサーバーはスキップされました",
     "replaceExisting": "既存のサーバーを置換",
     "mergeWithExisting": "既存のサーバーと統合"
+  },
+  "skills": {
+    "title": "スキル",
+    "subtitle": "エージェントのスキルを教え、管理します。",
+    "totalSkills": "スキル",
+    "teachNew": "新規追加",
+    "teachSkill": "スキルを教える",
+    "teach": "教える",
+    "skillsList": "スキル",
+    "skillsListDescription": "エージェントに教えたすべてのスキル。",
+    "noSkills": "スキルが設定されていません",
+    "namePlaceholder": "スキル名（例：要約）",
+    "descriptionPlaceholder": "スキルの簡単な説明",
+    "contentPlaceholder": "スキルの内容または指示...",
+    "fillAllFields": "すべてのフィールドを入力してください",
+    "teachError": "スキルの追加に失敗しました",
+    "removeSkill": "スキルを削除",
+    "removeConfirm": "スキル「{{name}}」を削除してもよろしいですか？",
+    "removeError": "スキルの削除に失敗しました",
+    "created": "作成日",
+    "updated": "更新日",
+    "openClawOnly": "OpenClaw専用",
+    "openClawOnlyDescription": "スキルはOpenClawサーバーでのみ利用可能です。"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -48,7 +48,8 @@
     "backupRestore": "백업 및 복원",
     "backupServers": "서버 백업",
     "restoreServers": "서버 복원",
-    "contribute": "기여하기"
+    "contribute": "기여하기",
+    "skills": "스킬"
   },
   "home": {
     "connectionError": "연결 오류",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "중복 서버를 건너뛰었습니다",
     "replaceExisting": "기존 서버 교체",
     "mergeWithExisting": "기존 서버와 병합"
+  },
+  "skills": {
+    "title": "스킬",
+    "subtitle": "에이전트의 스킬을 가르치고 관리합니다.",
+    "totalSkills": "스킬",
+    "teachNew": "새로 가르치기",
+    "teachSkill": "스킬 가르치기",
+    "teach": "가르치기",
+    "skillsList": "스킬",
+    "skillsListDescription": "에이전트에게 가르친 모든 스킬.",
+    "noSkills": "구성된 스킬 없음",
+    "namePlaceholder": "스킬 이름 (예: 요약)",
+    "descriptionPlaceholder": "스킬에 대한 간단한 설명",
+    "contentPlaceholder": "스킬 내용 또는 지침...",
+    "fillAllFields": "모든 필드를 입력하세요",
+    "teachError": "스킬 가르치기 실패",
+    "removeSkill": "스킬 삭제",
+    "removeConfirm": "스킬 \"{{name}}\"을(를) 삭제하시겠습니까?",
+    "removeError": "스킬 삭제 실패",
+    "created": "생성일",
+    "updated": "수정일",
+    "openClawOnly": "OpenClaw 전용",
+    "openClawOnlyDescription": "스킬은 OpenClaw 서버에서만 사용할 수 있습니다."
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -48,7 +48,8 @@
     "backupRestore": "Backup e Restauração",
     "backupServers": "Backup de Servidores",
     "restoreServers": "Restaurar Servidores",
-    "contribute": "Contribuir"
+    "contribute": "Contribuir",
+    "skills": "Habilidades"
   },
   "home": {
     "connectionError": "Erro de Conexão",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "Servidores duplicados foram ignorados",
     "replaceExisting": "Substituir servidores existentes",
     "mergeWithExisting": "Mesclar com servidores existentes"
+  },
+  "skills": {
+    "title": "Habilidades",
+    "subtitle": "Ensine e gerencie habilidades para seu agente.",
+    "totalSkills": "HABILIDADES",
+    "teachNew": "Ensinar Nova",
+    "teachSkill": "Ensinar Habilidade",
+    "teach": "Ensinar",
+    "skillsList": "Habilidades",
+    "skillsListDescription": "Todas as habilidades ensinadas ao agente.",
+    "noSkills": "Nenhuma habilidade configurada",
+    "namePlaceholder": "Nome da habilidade (ex. resumir)",
+    "descriptionPlaceholder": "Descrição breve da habilidade",
+    "contentPlaceholder": "Conteúdo ou instruções da habilidade...",
+    "fillAllFields": "Por favor, preencha todos os campos",
+    "teachError": "Falha ao ensinar habilidade",
+    "removeSkill": "Remover Habilidade",
+    "removeConfirm": "Tem certeza de que deseja remover a habilidade \"{{name}}\"?",
+    "removeError": "Falha ao remover habilidade",
+    "created": "Criada",
+    "updated": "Atualizada",
+    "openClawOnly": "Apenas OpenClaw",
+    "openClawOnlyDescription": "Habilidades estão disponíveis apenas para servidores OpenClaw."
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -48,7 +48,8 @@
     "backupRestore": "Резервное копирование и восстановление",
     "backupServers": "Резервное копирование серверов",
     "restoreServers": "Восстановление серверов",
-    "contribute": "Внести вклад"
+    "contribute": "Внести вклад",
+    "skills": "Навыки"
   },
   "home": {
     "connectionError": "Ошибка подключения",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "Дублирующиеся серверы были пропущены",
     "replaceExisting": "Заменить существующие серверы",
     "mergeWithExisting": "Объединить с существующими серверами"
+  },
+  "skills": {
+    "title": "Навыки",
+    "subtitle": "Обучайте и управляйте навыками вашего агента.",
+    "totalSkills": "НАВЫКИ",
+    "teachNew": "Обучить новый",
+    "teachSkill": "Обучить навык",
+    "teach": "Обучить",
+    "skillsList": "Навыки",
+    "skillsListDescription": "Все навыки, которым обучен агент.",
+    "noSkills": "Навыки не настроены",
+    "namePlaceholder": "Название навыка (напр. резюмировать)",
+    "descriptionPlaceholder": "Краткое описание навыка",
+    "contentPlaceholder": "Содержание или инструкции навыка...",
+    "fillAllFields": "Пожалуйста, заполните все поля",
+    "teachError": "Не удалось обучить навык",
+    "removeSkill": "Удалить навык",
+    "removeConfirm": "Вы уверены, что хотите удалить навык \"{{name}}\"?",
+    "removeError": "Не удалось удалить навык",
+    "created": "Создан",
+    "updated": "Обновлён",
+    "openClawOnly": "Только OpenClaw",
+    "openClawOnlyDescription": "Навыки доступны только для серверов OpenClaw."
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -48,7 +48,8 @@
     "backupRestore": "备份与恢复",
     "backupServers": "备份服务器",
     "restoreServers": "恢复服务器",
-    "contribute": "贡献"
+    "contribute": "贡献",
+    "skills": "技能"
   },
   "home": {
     "connectionError": "连接错误",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "重复的服务器已跳过",
     "replaceExisting": "替换现有服务器",
     "mergeWithExisting": "与现有服务器合并"
+  },
+  "skills": {
+    "title": "技能",
+    "subtitle": "教授和管理代理的技能。",
+    "totalSkills": "技能",
+    "teachNew": "教授新技能",
+    "teachSkill": "教授技能",
+    "teach": "教授",
+    "skillsList": "技能",
+    "skillsListDescription": "所有已教授给代理的技能。",
+    "noSkills": "未配置技能",
+    "namePlaceholder": "技能名称（例如：总结）",
+    "descriptionPlaceholder": "技能的简短描述",
+    "contentPlaceholder": "技能内容或指令...",
+    "fillAllFields": "请填写所有字段",
+    "teachError": "教授技能失败",
+    "removeSkill": "删除技能",
+    "removeConfirm": "确定要删除技能「{{name}}」吗？",
+    "removeError": "删除技能失败",
+    "created": "创建时间",
+    "updated": "更新时间",
+    "openClawOnly": "仅限 OpenClaw",
+    "openClawOnlyDescription": "技能仅适用于 OpenClaw 服务器。"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -48,7 +48,8 @@
     "backupRestore": "備份與還原",
     "backupServers": "備份伺服器",
     "restoreServers": "還原伺服器",
-    "contribute": "貢獻"
+    "contribute": "貢獻",
+    "skills": "技能"
   },
   "home": {
     "connectionError": "連線錯誤",
@@ -178,5 +179,28 @@
     "duplicateSkipped": "重複的伺服器已略過",
     "replaceExisting": "取代現有伺服器",
     "mergeWithExisting": "與現有伺服器合併"
+  },
+  "skills": {
+    "title": "技能",
+    "subtitle": "教授和管理代理的技能。",
+    "totalSkills": "技能",
+    "teachNew": "教授新技能",
+    "teachSkill": "教授技能",
+    "teach": "教授",
+    "skillsList": "技能",
+    "skillsListDescription": "所有已教授給代理的技能。",
+    "noSkills": "未設定技能",
+    "namePlaceholder": "技能名稱（例如：摘要）",
+    "descriptionPlaceholder": "技能的簡短描述",
+    "contentPlaceholder": "技能內容或指令...",
+    "fillAllFields": "請填寫所有欄位",
+    "teachError": "教授技能失敗",
+    "removeSkill": "刪除技能",
+    "removeConfirm": "確定要刪除技能「{{name}}」嗎？",
+    "removeError": "刪除技能失敗",
+    "created": "建立時間",
+    "updated": "更新時間",
+    "openClawOnly": "僅限 OpenClaw",
+    "openClawOnlyDescription": "技能僅適用於 OpenClaw 伺服器。"
   }
 }

--- a/src/services/apple-intelligence/AppleChatProvider.ts
+++ b/src/services/apple-intelligence/AppleChatProvider.ts
@@ -34,6 +34,7 @@ export class AppleChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private connected = false

--- a/src/services/claude/ClaudeChatProvider.ts
+++ b/src/services/claude/ClaudeChatProvider.ts
@@ -61,6 +61,7 @@ export class ClaudeChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private baseUrl: string

--- a/src/services/echo/EchoChatProvider.ts
+++ b/src/services/echo/EchoChatProvider.ts
@@ -24,6 +24,7 @@ export class EchoChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private connected = false

--- a/src/services/emergent/EmergentChatProvider.ts
+++ b/src/services/emergent/EmergentChatProvider.ts
@@ -58,6 +58,7 @@ export class EmergentChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private baseUrl: string

--- a/src/services/gemini-nano/GeminiNanoChatProvider.ts
+++ b/src/services/gemini-nano/GeminiNanoChatProvider.ts
@@ -34,6 +34,7 @@ export class GeminiNanoChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private connected = false

--- a/src/services/gemini/GeminiChatProvider.ts
+++ b/src/services/gemini/GeminiChatProvider.ts
@@ -53,6 +53,7 @@ export class GeminiChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private baseUrl: string

--- a/src/services/kimi/KimiChatProvider.ts
+++ b/src/services/kimi/KimiChatProvider.ts
@@ -59,6 +59,7 @@ export class KimiChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private baseUrl: string

--- a/src/services/molt/client.ts
+++ b/src/services/molt/client.ts
@@ -10,6 +10,10 @@ import {
   RequestFrame,
   ResponseFrame,
   SendMessageParams,
+  Skill,
+  SkillsListResponse,
+  TeachSkillParams,
+  UpdateSkillParams,
 } from './types'
 
 const wsLogger = logger.create('WebSocket')
@@ -255,6 +259,22 @@ export class MoltGatewayClient {
 
   async getCronJobRuns(jobName: string): Promise<unknown> {
     return await this.request('cron.runs', { name: jobName })
+  }
+
+  async teachSkill(params: TeachSkillParams): Promise<Skill> {
+    return (await this.request('skills.teach', params)) as Skill
+  }
+
+  async listSkills(): Promise<SkillsListResponse> {
+    return (await this.request('skills.list')) as SkillsListResponse
+  }
+
+  async removeSkill(name: string): Promise<unknown> {
+    return await this.request('skills.remove', { name })
+  }
+
+  async updateSkill(params: UpdateSkillParams): Promise<Skill> {
+    return (await this.request('skills.update', params)) as Skill
   }
 
   async sendAgentRequest(

--- a/src/services/molt/types.ts
+++ b/src/services/molt/types.ts
@@ -163,6 +163,31 @@ export type AgentEvent = {
   ts: number
 }
 
+// Skills types
+export interface TeachSkillParams {
+  name: string
+  description: string
+  content: string
+}
+
+export interface UpdateSkillParams {
+  name: string
+  description?: string
+  content?: string
+}
+
+export interface Skill {
+  name: string
+  description: string
+  content: string
+  createdAtMs: number
+  updatedAtMs: number
+}
+
+export interface SkillsListResponse {
+  skills: Skill[]
+}
+
 // Event types
 export type GatewayEvent =
   | { event: 'agent'; payload: AgentEvent; seq?: number }

--- a/src/services/molt/useMoltGateway.ts
+++ b/src/services/molt/useMoltGateway.ts
@@ -11,6 +11,10 @@ import {
   HealthStatus,
   MoltConfig,
   SendMessageParams,
+  Skill,
+  SkillsListResponse,
+  TeachSkillParams,
+  UpdateSkillParams,
 } from './types'
 
 const gatewayLogger = logger.create('MoltGateway')
@@ -38,6 +42,10 @@ export interface UseMoltGatewayResult {
   runCronJob: (jobName: string) => Promise<unknown>
   removeCronJob: (jobName: string) => Promise<unknown>
   getCronJobRuns: (jobName: string) => Promise<unknown>
+  teachSkill: (params: TeachSkillParams) => Promise<Skill>
+  listSkills: () => Promise<SkillsListResponse>
+  removeSkill: (name: string) => Promise<unknown>
+  updateSkill: (params: UpdateSkillParams) => Promise<Skill>
 }
 
 export function useMoltGateway(config: MoltConfig): UseMoltGatewayResult {
@@ -247,6 +255,43 @@ export function useMoltGateway(config: MoltConfig): UseMoltGatewayResult {
     [client],
   )
 
+  const teachSkill = useCallback(
+    async (params: TeachSkillParams) => {
+      if (!client) {
+        throw new Error('Client not connected')
+      }
+      return await client.teachSkill(params)
+    },
+    [client],
+  )
+
+  const listSkills = useCallback(async () => {
+    if (!client) {
+      throw new Error('Client not connected')
+    }
+    return await client.listSkills()
+  }, [client])
+
+  const removeSkill = useCallback(
+    async (name: string) => {
+      if (!client) {
+        throw new Error('Client not connected')
+      }
+      return await client.removeSkill(name)
+    },
+    [client],
+  )
+
+  const updateSkill = useCallback(
+    async (params: UpdateSkillParams) => {
+      if (!client) {
+        throw new Error('Client not connected')
+      }
+      return await client.updateSkill(params)
+    },
+    [client],
+  )
+
   useEffect(() => {
     return () => {
       if (clientRef.current) {
@@ -278,5 +323,9 @@ export function useMoltGateway(config: MoltConfig): UseMoltGatewayResult {
     runCronJob,
     removeCronJob,
     getCronJobRuns,
+    teachSkill,
+    listSkills,
+    removeSkill,
+    updateSkill,
   }
 }

--- a/src/services/ollama/OllamaChatProvider.ts
+++ b/src/services/ollama/OllamaChatProvider.ts
@@ -32,6 +32,7 @@ export class OllamaChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private client: Ollama

--- a/src/services/openai/OpenAIChatProvider.ts
+++ b/src/services/openai/OpenAIChatProvider.ts
@@ -59,6 +59,7 @@ export class OpenAIChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private baseUrl: string

--- a/src/services/openrouter/OpenRouterChatProvider.ts
+++ b/src/services/openrouter/OpenRouterChatProvider.ts
@@ -66,6 +66,7 @@ export class OpenRouterChatProvider implements ChatProvider {
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   private baseUrl: string

--- a/src/services/providers/MoltChatProvider.ts
+++ b/src/services/providers/MoltChatProvider.ts
@@ -25,6 +25,7 @@ export class MoltChatProvider implements ChatProvider {
     persistentHistory: true,
     scheduler: true,
     gatewaySnapshot: true,
+    skills: true,
   }
 
   private client: MoltGatewayClient

--- a/src/services/providers/__tests__/CachedChatProvider.test.ts
+++ b/src/services/providers/__tests__/CachedChatProvider.test.ts
@@ -29,6 +29,7 @@ function createMockProvider(overrides: Partial<ChatProvider> = {}): ChatProvider
     persistentHistory: false,
     scheduler: false,
     gatewaySnapshot: false,
+    skills: false,
   }
 
   return {

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -80,6 +80,8 @@ export interface ProviderCapabilities {
   scheduler: boolean
   /** Gateway snapshot with presence & instance info */
   gatewaySnapshot: boolean
+  /** Skills management (teach, list, remove) */
+  skills: boolean
 }
 
 /**


### PR DESCRIPTION
Introduces a new skills management feature for Molt (OpenClaw) servers:
- Add skills.teach, skills.list, skills.remove, and skills.update RPC
  methods to MoltGatewayClient and useMoltGateway hook
- Add TeachSkillParams, UpdateSkillParams, Skill, and SkillsListResponse
  types to the Molt protocol types
- Add skills capability to ProviderCapabilities interface and set it on
  all providers (true for Molt, false for all others)
- Create Skills screen (app/skills.tsx) with teach form, list view, and
  remove functionality
- Register skills route in app layout and add navigation from settings
- Add i18n translations for all 11 supported locales

https://claude.ai/code/session_0111DbQxprswZkvNMU8PKsA1