### PR TITLE
Fix no-explicit-any lint warnings across 3 files

### DIFF
--- a/app/__tests__/app-startup.test.tsx
+++ b/app/__tests__/app-startup.test.tsx
@@ -57,9 +57,9 @@ jest.mock('../../src/utils/device', () => ({
   useIsFoldable: () => false,
   useFoldState: () => 'folded',
   useOrientation: () => 'portrait',
-  useResponsiveValue: (phone: any) => phone,
-  useResponsiveValueWithFoldable: (phone: any) => phone,
-  useFoldResponsiveValue: (folded: any) => folded,
+  useResponsiveValue: (phone: unknown) => phone,
+  useResponsiveValueWithFoldable: (phone: unknown) => phone,
+  useFoldResponsiveValue: (folded: unknown) => folded,
   useContentContainerStyle: () => ({}),
   useScreenDimensions: () => ({ width: 375, height: 667 }),
 }))
@@ -118,7 +118,7 @@ jest.mock('../../src/theme', () => {
 // Mock jotai
 jest.mock('jotai', () => ({
   ...jest.requireActual('jotai'),
-  useAtom: (atom: any) => {
+  useAtom: (atom: { init?: unknown }) => {
     const [value, setValue] = jest
       .requireActual('react')
       .useState(atom.init !== undefined ? atom.init : null)

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -477,7 +477,11 @@ export function ChatMessage({ message }: ChatMessageProps) {
                 accessibilityLabel={showCheck ? 'Copied' : intent.label}
               >
                 <Ionicons
-                  name={(showCheck ? 'checkmark' : intentIcon(intent.action)) as any}
+                  name={
+                    (showCheck ? 'checkmark' : intentIcon(intent.action)) as React.ComponentProps<
+                      typeof Ionicons
+                    >['name']
+                  }
                   size={16}
                   color={theme.colors.primary}
                   style={styles.intentButtonIcon}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -78,7 +78,7 @@ class Logger {
   /**
    * Log debug message
    */
-  debug(message: string, ...args: any[]): void {
+  debug(message: string, ...args: unknown[]): void {
     if (!this.shouldLog(LogLevel.DEBUG)) return
 
     const formatted = this.formatMessage('DEBUG', message)
@@ -88,7 +88,7 @@ class Logger {
   /**
    * Log info message
    */
-  info(message: string, ...args: any[]): void {
+  info(message: string, ...args: unknown[]): void {
     if (!this.shouldLog(LogLevel.INFO)) return
 
     const formatted = this.formatMessage('INFO', message)
@@ -98,7 +98,7 @@ class Logger {
   /**
    * Log warning message
    */
-  warn(message: string, ...args: any[]): void {
+  warn(message: string, ...args: unknown[]): void {
     if (!this.shouldLog(LogLevel.WARN)) return
 
     const formatted = this.formatMessage('WARN', message)
@@ -108,7 +108,7 @@ class Logger {
   /**
    * Log error message
    */
-  error(message: string, ...args: any[]): void {
+  error(message: string, ...args: unknown[]): void {
     if (!this.shouldLog(LogLevel.ERROR)) return
 
     const formatted = this.formatMessage('ERROR', message)
@@ -118,7 +118,7 @@ class Logger {
   /**
    * Log an error object
    */
-  logError(message: string, error: Error | unknown, ...args: any[]): void {
+  logError(message: string, error: Error | unknown, ...args: unknown[]): void {
     if (!this.shouldLog(LogLevel.ERROR)) return
 
     const formatted = this.formatMessage('ERROR', message)


### PR DESCRIPTION
Replace `any` types with proper types (`unknown`, typed props) in
test mocks, Ionicons name prop, and logger rest parameters to
eliminate all 10 ESLint @typescript-eslint/no-explicit-any warnings.

https://claude.ai/code/session_015Xxy4r9J7h8fv3rTTyfNGU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved type safety across test mocks and utility functions with more precise type annotations. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->