### PR TITLE
Add custom chat provider for OpenAI-compatible APIs with custom domains

### DIFF
--- a/app/add-server.tsx
+++ b/app/add-server.tsx
@@ -29,13 +29,14 @@ export default function AddServerScreen() {
   const [providerType, setProviderType] = useState<ProviderType>('molt')
   const [model, setModel] = useState('')
 
-  const needsUrl = providerType === 'molt' || providerType === 'ollama'
+  const needsUrl = providerType === 'molt' || providerType === 'ollama' || providerType === 'custom'
   const needsToken =
     providerType === 'molt' ||
     providerType === 'claude' ||
     providerType === 'openai' ||
     providerType === 'openrouter' ||
-    providerType === 'emergent'
+    providerType === 'emergent' ||
+    providerType === 'custom'
 
   const handleAdd = async () => {
     if (providerType === 'molt' && url.trim() && token.trim()) {
@@ -98,6 +99,16 @@ export default function AddServerScreen() {
         },
         token.trim(),
       )
+    } else if (providerType === 'custom' && url.trim() && token.trim()) {
+      await addServer(
+        {
+          name: name.trim() || 'My Custom Provider',
+          url: url.trim(),
+          providerType: 'custom',
+          model: model.trim() || undefined,
+        },
+        token.trim(),
+      )
     } else if (providerType === 'echo') {
       await addServer(
         {
@@ -134,7 +145,7 @@ export default function AddServerScreen() {
       if (needsToken && !token.trim()) {
         Alert.alert(
           'Error',
-          providerType === 'claude' || providerType === 'openai'
+          providerType === 'claude' || providerType === 'openai' || providerType === 'custom'
             ? 'API Key is required'
             : providerType === 'emergent'
               ? 'Universal Key is required'
@@ -213,7 +224,9 @@ export default function AddServerScreen() {
                               ? 'My OpenRouter'
                               : providerType === 'emergent'
                                 ? 'My Emergent'
-                                : 'My Server'
+                                : providerType === 'custom'
+                                  ? 'My Custom Provider'
+                                  : 'My Server'
               }
               autoCapitalize="none"
               autoCorrect={false}
@@ -245,7 +258,11 @@ export default function AddServerScreen() {
                 value={url}
                 onChangeText={setUrl}
                 placeholder={
-                  providerType === 'ollama' ? 'http://localhost:11434' : 'wss://gateway.example.com'
+                  providerType === 'ollama'
+                    ? 'http://localhost:11434'
+                    : providerType === 'custom'
+                      ? 'https://api.example.com'
+                      : 'wss://gateway.example.com'
                 }
                 autoCapitalize="none"
                 autoCorrect={false}
@@ -384,6 +401,31 @@ export default function AddServerScreen() {
                   value={model}
                   onChangeText={setModel}
                   placeholder="openai/gpt-4o"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              </View>
+            </>
+          )}
+
+          {providerType === 'custom' && (
+            <>
+              <View style={styles.formRow}>
+                <TextInput
+                  label="API Key"
+                  value={token}
+                  onChangeText={setToken}
+                  secureTextEntry
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              </View>
+              <View style={styles.formRow}>
+                <TextInput
+                  label="Model"
+                  value={model}
+                  onChangeText={setModel}
+                  placeholder="gpt-4o"
                   autoCapitalize="none"
                   autoCorrect={false}
                 />

--- a/app/edit-server.tsx
+++ b/app/edit-server.tsx
@@ -66,6 +66,11 @@ export default function EditServerScreen() {
       return
     }
 
+    if (providerType === 'custom' && !url.trim()) {
+      Alert.alert('Error', 'URL is required')
+      return
+    }
+
     let effectiveUrl = url.trim()
     if (providerType === 'echo') {
       effectiveUrl = ''
@@ -224,21 +229,27 @@ export default function EditServerScreen() {
                               ? 'My OpenRouter'
                               : providerType === 'emergent'
                                 ? 'My Emergent'
-                                : 'My Server'
+                                : providerType === 'custom'
+                                  ? 'My Custom Provider'
+                                  : 'My Server'
               }
               autoCapitalize="none"
               autoCorrect={false}
             />
           </View>
 
-          {(providerType === 'molt' || providerType === 'ollama') && (
+          {(providerType === 'molt' || providerType === 'ollama' || providerType === 'custom') && (
             <View style={styles.formRow}>
               <TextInput
                 label="URL"
                 value={url}
                 onChangeText={setUrl}
                 placeholder={
-                  providerType === 'ollama' ? 'http://localhost:11434' : 'wss://gateway.example.com'
+                  providerType === 'ollama'
+                    ? 'http://localhost:11434'
+                    : providerType === 'custom'
+                      ? 'https://api.example.com'
+                      : 'wss://gateway.example.com'
                 }
                 autoCapitalize="none"
                 autoCorrect={false}
@@ -287,7 +298,8 @@ export default function EditServerScreen() {
           {(providerType === 'claude' ||
             providerType === 'openai' ||
             providerType === 'openrouter' ||
-            providerType === 'emergent') && (
+            providerType === 'emergent' ||
+            providerType === 'custom') && (
             <>
               <View style={styles.formRow}>
                 <TextInput
@@ -369,7 +381,7 @@ export default function EditServerScreen() {
                     value={model}
                     onChangeText={setModel}
                     placeholder={
-                      providerType === 'openai'
+                      providerType === 'openai' || providerType === 'custom'
                         ? 'gpt-4o'
                         : providerType === 'openrouter'
                           ? 'openai/gpt-4o'

--- a/src/config/providerOptions.tsx
+++ b/src/config/providerOptions.tsx
@@ -35,6 +35,7 @@ export function getProviderIcon(type: ProviderType, color: string): React.ReactN
     'gemini-nano': GeminiNanoIcon,
     emergent: EmergentIcon,
     kimi: KimiIcon,
+    custom: DefaultIcon,
   }
 
   const Icon = icons[type] ?? DefaultIcon
@@ -69,6 +70,11 @@ export function getAllProviderOptions(color: string) {
       : []),
     { value: 'emergent', label: 'Emergent', icon: getProviderIcon('emergent', color) },
     { value: 'kimi', label: 'Kimi', icon: getProviderIcon('kimi', color) },
+    {
+      value: 'custom',
+      label: 'Custom (OpenAI-compatible)',
+      icon: getProviderIcon('custom', color),
+    },
     { value: 'echo', label: 'Echo Server', icon: getProviderIcon('echo', color) },
   ]
   return options
@@ -129,6 +135,11 @@ export function getBasicProviderOptions(color: string) {
       value: 'kimi' as ProviderType,
       label: 'Kimi',
       icon: getProviderIcon('kimi', color),
+    },
+    {
+      value: 'custom' as ProviderType,
+      label: 'Custom (OpenAI-compatible)',
+      icon: getProviderIcon('custom', color),
     },
     {
       value: 'echo' as ProviderType,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -23,6 +23,8 @@ export const DEFAULT_MODELS = {
   EMERGENT: 'claude-sonnet-4-5',
   /** Default Kimi (Moonshot AI) model */
   KIMI: 'moonshot-v1-8k',
+  /** Default model for custom OpenAI-compatible providers */
+  CUSTOM: 'gpt-4o',
 } as const
 
 /**
@@ -41,6 +43,8 @@ export const API_CONFIG = {
   GEMINI_MAX_TOKENS: 8192,
   /** Default max tokens for Kimi API responses */
   KIMI_MAX_TOKENS: 4096,
+  /** Default max tokens for custom OpenAI-compatible API responses */
+  CUSTOM_MAX_TOKENS: 4096,
 } as const
 
 /**

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -77,16 +77,19 @@
       "myServer": "Mein Server",
       "myOllama": "Mein Ollama",
       "myEchoServer": "Mein Echo-Server",
-      "myClaude": "Mein Claude"
+      "myClaude": "Mein Claude",
+      "myCustomProvider": "Mein Benutzerdefinierter Anbieter"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Echo-Server"
+      "echoServer": "Echo-Server",
+      "custom": "Benutzerdefiniert (OpenAI-kompatibel)"
     },
     "appleDescription": "Verwendet Apple Foundation Models, um KI vollständig auf dem Gerät über CoreML auszuführen. Erfordert iOS 26+ mit Apple Intelligence-Unterstützung.",
+    "customDescription": "Verbinden Sie sich mit jeder OpenAI-kompatiblen API, indem Sie Ihre eigene Endpoint-URL angeben.",
     "errors": {
       "urlRequired": "URL ist erforderlich",
       "tokenRequired": "Token ist erforderlich",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -77,16 +77,19 @@
       "myServer": "My Server",
       "myOllama": "My Ollama",
       "myEchoServer": "My Echo Server",
-      "myClaude": "My Claude"
+      "myClaude": "My Claude",
+      "myCustomProvider": "My Custom Provider"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Echo Server"
+      "echoServer": "Echo Server",
+      "custom": "Custom (OpenAI-compatible)"
     },
     "appleDescription": "Uses Apple Foundation Models to run AI entirely on-device via CoreML. Requires iOS 26+ with Apple Intelligence support.",
+    "customDescription": "Connect to any OpenAI-compatible API by providing your own endpoint URL.",
     "errors": {
       "urlRequired": "URL is required",
       "tokenRequired": "Token is required",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -77,16 +77,19 @@
       "myServer": "Mi Servidor",
       "myOllama": "Mi Ollama",
       "myEchoServer": "Mi Servidor Echo",
-      "myClaude": "Mi Claude"
+      "myClaude": "Mi Claude",
+      "myCustomProvider": "Mi Proveedor Personalizado"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Servidor Echo"
+      "echoServer": "Servidor Echo",
+      "custom": "Personalizado (compatible con OpenAI)"
     },
     "appleDescription": "Utiliza Apple Foundation Models para ejecutar IA completamente en el dispositivo mediante CoreML. Requiere iOS 26+ con soporte de Apple Intelligence.",
+    "customDescription": "Conéctate a cualquier API compatible con OpenAI proporcionando tu propia URL de endpoint.",
     "errors": {
       "urlRequired": "La URL es requerida",
       "tokenRequired": "El token es requerido",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -77,16 +77,19 @@
       "myServer": "Mon serveur",
       "myOllama": "Mon Ollama",
       "myEchoServer": "Mon serveur Echo",
-      "myClaude": "Mon Claude"
+      "myClaude": "Mon Claude",
+      "myCustomProvider": "Mon Fournisseur Personnalisé"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Serveur Echo"
+      "echoServer": "Serveur Echo",
+      "custom": "Personnalisé (compatible OpenAI)"
     },
     "appleDescription": "Utilise les modèles Apple Foundation pour exécuter l'IA entièrement sur l'appareil via CoreML. Nécessite iOS 26+ avec support Apple Intelligence.",
+    "customDescription": "Connectez-vous à n'importe quelle API compatible OpenAI en fournissant votre propre URL d'endpoint.",
     "errors": {
       "urlRequired": "L'URL est requise",
       "tokenRequired": "Le jeton est requis",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -77,16 +77,19 @@
       "myServer": "मेरा सर्वर",
       "myOllama": "मेरा Ollama",
       "myEchoServer": "मेरा Echo सर्वर",
-      "myClaude": "मेरा Claude"
+      "myClaude": "मेरा Claude",
+      "myCustomProvider": "मेरा कस्टम प्रोवाइडर"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Echo सर्वर"
+      "echoServer": "Echo सर्वर",
+      "custom": "कस्टम (OpenAI-संगत)"
     },
     "appleDescription": "CoreML के माध्यम से पूरी तरह से डिवाइस पर AI चलाने के लिए Apple Foundation Models का उपयोग करता है। iOS 26+ और Apple Intelligence सपोर्ट आवश्यक है।",
+    "customDescription": "अपना खुद का एंडपॉइंट URL प्रदान करके किसी भी OpenAI-संगत API से कनेक्ट करें।",
     "errors": {
       "urlRequired": "URL आवश्यक है",
       "tokenRequired": "टोकन आवश्यक है",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -77,16 +77,19 @@
       "myServer": "マイサーバー",
       "myOllama": "マイOllama",
       "myEchoServer": "マイEchoサーバー",
-      "myClaude": "マイClaude"
+      "myClaude": "マイClaude",
+      "myCustomProvider": "マイカスタムプロバイダー"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Echoサーバー"
+      "echoServer": "Echoサーバー",
+      "custom": "カスタム（OpenAI互換）"
     },
     "appleDescription": "Apple Foundation Modelsを使用して、CoreML経由でAIを完全にデバイス上で実行します。Apple Intelligenceに対応したiOS 26以降が必要です。",
+    "customDescription": "独自のエンドポイントURLを指定して、任意のOpenAI互換APIに接続します。",
     "errors": {
       "urlRequired": "URLは必須です",
       "tokenRequired": "トークンは必須です",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -77,16 +77,19 @@
       "myServer": "내 서버",
       "myOllama": "내 Ollama",
       "myEchoServer": "내 Echo 서버",
-      "myClaude": "내 Claude"
+      "myClaude": "내 Claude",
+      "myCustomProvider": "내 커스텀 제공자"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Echo 서버"
+      "echoServer": "Echo 서버",
+      "custom": "커스텀 (OpenAI 호환)"
     },
     "appleDescription": "CoreML을 통해 기기에서 완전히 AI를 실행하기 위해 Apple Foundation Models를 사용합니다. Apple Intelligence를 지원하는 iOS 26+ 이상이 필요합니다.",
+    "customDescription": "자체 엔드포인트 URL을 제공하여 OpenAI 호환 API에 연결합니다.",
     "errors": {
       "urlRequired": "URL은 필수입니다",
       "tokenRequired": "토큰은 필수입니다",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -77,16 +77,19 @@
       "myServer": "Meu Servidor",
       "myOllama": "Meu Ollama",
       "myEchoServer": "Meu Servidor Echo",
-      "myClaude": "Meu Claude"
+      "myClaude": "Meu Claude",
+      "myCustomProvider": "Meu Provedor Personalizado"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Servidor Echo"
+      "echoServer": "Servidor Echo",
+      "custom": "Personalizado (compatível com OpenAI)"
     },
     "appleDescription": "Usa Apple Foundation Models para executar IA totalmente no dispositivo via CoreML. Requer iOS 26+ com suporte a Apple Intelligence.",
+    "customDescription": "Conecte-se a qualquer API compatível com OpenAI fornecendo sua própria URL de endpoint.",
     "errors": {
       "urlRequired": "URL é obrigatória",
       "tokenRequired": "Token é obrigatório",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -77,16 +77,19 @@
       "myServer": "Мой сервер",
       "myOllama": "Мой Ollama",
       "myEchoServer": "Мой Echo-сервер",
-      "myClaude": "Мой Claude"
+      "myClaude": "Мой Claude",
+      "myCustomProvider": "Мой пользовательский провайдер"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "Echo-сервер"
+      "echoServer": "Echo-сервер",
+      "custom": "Пользовательский (совместимый с OpenAI)"
     },
     "appleDescription": "Использует Apple Foundation Models для запуска ИИ полностью на устройстве через CoreML. Требуется iOS 26+ с поддержкой Apple Intelligence.",
+    "customDescription": "Подключитесь к любому OpenAI-совместимому API, указав свой URL-адрес эндпоинта.",
     "errors": {
       "urlRequired": "URL обязателен",
       "tokenRequired": "Токен обязателен",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -77,16 +77,19 @@
       "myServer": "我的服务器",
       "myOllama": "我的 Ollama",
       "myEchoServer": "我的回声服务器",
-      "myClaude": "我的 Claude"
+      "myClaude": "我的 Claude",
+      "myCustomProvider": "我的自定义提供商"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "回声服务器"
+      "echoServer": "回声服务器",
+      "custom": "自定义（OpenAI 兼容）"
     },
     "appleDescription": "使用 Apple Foundation Models 通过 CoreML 在设备上完全本地运行 AI。需要 iOS 26+ 并支持 Apple Intelligence。",
+    "customDescription": "通过提供自己的端点 URL 连接到任何 OpenAI 兼容的 API。",
     "errors": {
       "urlRequired": "URL 为必填项",
       "tokenRequired": "令牌为必填项",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -77,16 +77,19 @@
       "myServer": "我的伺服器",
       "myOllama": "我的 Ollama",
       "myEchoServer": "我的回音伺服器",
-      "myClaude": "我的 Claude"
+      "myClaude": "我的 Claude",
+      "myCustomProvider": "我的自訂供應商"
     },
     "providers": {
       "openClaw": "OpenClaw",
       "ollama": "Ollama",
       "claude": "Claude",
       "appleIntelligence": "Apple Intelligence",
-      "echoServer": "回音伺服器"
+      "echoServer": "回音伺服器",
+      "custom": "自訂（OpenAI 相容）"
     },
     "appleDescription": "使用 Apple Foundation Models 透過 CoreML 在裝置上完全本機執行 AI。需要 iOS 26+ 並支援 Apple Intelligence。",
+    "customDescription": "透過提供自己的端點 URL 連接到任何 OpenAI 相容的 API。",
     "errors": {
       "urlRequired": "URL 為必填欄位",
       "tokenRequired": "權杖為必填欄位",

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -60,13 +60,14 @@ export function SetupScreen() {
     },
   })
 
-  const needsUrl = providerType === 'molt' || providerType === 'ollama'
+  const needsUrl = providerType === 'molt' || providerType === 'ollama' || providerType === 'custom'
   const needsToken =
     providerType === 'molt' ||
     providerType === 'claude' ||
     providerType === 'openai' ||
     providerType === 'openrouter' ||
-    providerType === 'gemini'
+    providerType === 'gemini' ||
+    providerType === 'custom'
 
   const handleComplete = async () => {
     if (providerType === 'molt' && localUrl.trim() && localToken.trim()) {
@@ -237,11 +238,30 @@ export function SetupScreen() {
       }))
 
       setOnboardingCompleted(true)
+    } else if (providerType === 'custom' && localUrl.trim() && localToken.trim()) {
+      const serverId = await addServer(
+        {
+          name: 'My Custom Provider',
+          url: localUrl.trim(),
+          providerType: 'custom',
+          model: localModel.trim() || undefined,
+        },
+        localToken.trim(),
+      )
+
+      const sessionKey = DEFAULT_SESSION_KEY
+      setCurrentSessionKey(sessionKey)
+      setServerSessions((prev) => ({
+        ...prev,
+        [serverId]: sessionKey,
+      }))
+
+      setOnboardingCompleted(true)
     }
   }
 
   const isValid =
-    providerType === 'molt'
+    providerType === 'molt' || providerType === 'custom'
       ? localUrl.trim().length > 0 && localToken.trim().length > 0
       : providerType === 'claude' ||
           providerType === 'openai' ||
@@ -281,7 +301,9 @@ export function SetupScreen() {
               placeholder={
                 providerType === 'ollama'
                   ? 'http://localhost:11434'
-                  : 'https://your-gateway.example.com'
+                  : providerType === 'custom'
+                    ? 'https://api.example.com'
+                    : 'https://your-gateway.example.com'
               }
               autoCapitalize="none"
               autoCorrect={false}
@@ -289,7 +311,9 @@ export function SetupScreen() {
               hint={
                 providerType === 'ollama'
                   ? 'The URL of your Ollama server'
-                  : 'The URL of your OpenClaw server'
+                  : providerType === 'custom'
+                    ? 'Base URL of your OpenAI-compatible API'
+                    : 'The URL of your OpenClaw server'
               }
             />
           )}
@@ -300,7 +324,8 @@ export function SetupScreen() {
                 providerType === 'claude' ||
                 providerType === 'openai' ||
                 providerType === 'openrouter' ||
-                providerType === 'gemini'
+                providerType === 'gemini' ||
+                providerType === 'custom'
                   ? 'API Key'
                   : 'Token'
               }
@@ -310,7 +335,8 @@ export function SetupScreen() {
                 providerType === 'claude' ||
                 providerType === 'openai' ||
                 providerType === 'openrouter' ||
-                providerType === 'gemini'
+                providerType === 'gemini' ||
+                providerType === 'custom'
                   ? 'Your API key'
                   : 'Your authentication token'
               }
@@ -326,7 +352,9 @@ export function SetupScreen() {
                       ? 'Your OpenRouter API key'
                       : providerType === 'gemini'
                         ? 'Your Google AI API key'
-                        : 'Your authentication token for the gateway'
+                        : providerType === 'custom'
+                          ? 'API key for your OpenAI-compatible service'
+                          : 'Your authentication token for the gateway'
               }
             />
           )}
@@ -335,7 +363,8 @@ export function SetupScreen() {
             providerType === 'claude' ||
             providerType === 'openai' ||
             providerType === 'openrouter' ||
-            providerType === 'gemini') && (
+            providerType === 'gemini' ||
+            providerType === 'custom') && (
             <TextInput
               label="Model"
               value={localModel}
@@ -345,7 +374,7 @@ export function SetupScreen() {
                   ? 'llama3.2'
                   : providerType === 'claude'
                     ? 'claude-sonnet-4-5'
-                    : providerType === 'openai'
+                    : providerType === 'openai' || providerType === 'custom'
                       ? 'gpt-4o'
                       : providerType === 'gemini'
                         ? 'gemini-2.0-flash'
@@ -362,7 +391,9 @@ export function SetupScreen() {
                       ? 'OpenAI model to use (default: gpt-4o)'
                       : providerType === 'gemini'
                         ? 'Gemini model to use (default: gemini-2.0-flash)'
-                        : 'OpenRouter model to use (default: openai/gpt-4o)'
+                        : providerType === 'custom'
+                          ? 'Model identifier for your API (default: gpt-4o)'
+                          : 'OpenRouter model to use (default: openai/gpt-4o)'
               }
             />
           )}

--- a/src/services/custom/CustomChatProvider.ts
+++ b/src/services/custom/CustomChatProvider.ts
@@ -1,0 +1,321 @@
+import { API_CONFIG, DEFAULT_MODELS } from '../../constants'
+import {
+  ChatHistoryMessage,
+  ChatHistoryResponse,
+  ChatProvider,
+  ChatProviderEvent,
+  HealthStatus,
+  ProviderCapabilities,
+  ProviderConfig,
+  SendMessageParams,
+} from '../providers/types'
+
+interface CustomMessage {
+  role: 'user' | 'assistant' | 'system'
+  content: string | CustomContentPart[]
+}
+
+type CustomContentPart = CustomTextPart | CustomImagePart
+
+interface CustomTextPart {
+  type: 'text'
+  text: string
+}
+
+interface CustomImagePart {
+  type: 'image_url'
+  image_url: {
+    url: string
+  }
+}
+
+interface CustomStreamChunk {
+  id: string
+  choices: Array<{
+    delta: {
+      content?: string
+      role?: string
+    }
+    finish_reason: string | null
+  }>
+  error?: {
+    message: string
+  }
+}
+
+/**
+ * Chat provider for any OpenAI-compatible API with a custom domain.
+ *
+ * Uses the /v1/chat/completions endpoint with streaming support
+ * for real-time response delivery. The user must provide a base URL
+ * pointing to their OpenAI-compatible service.
+ */
+export class CustomChatProvider implements ChatProvider {
+  readonly capabilities: ProviderCapabilities = {
+    chat: true,
+    imageAttachments: true,
+    fileAttachments: false,
+    serverSessions: false,
+    persistentHistory: false,
+    scheduler: false,
+    gatewaySnapshot: false,
+    skills: false,
+  }
+
+  private baseUrl: string
+  private apiKey: string
+  private model: string
+  private connected = false
+  private connectionListeners: Array<(connected: boolean, reconnecting: boolean) => void> = []
+  private activeXhr: XMLHttpRequest | null = null
+
+  // In-memory conversation history keyed by session
+  private sessions: Map<string, CustomMessage[]> = new Map()
+
+  constructor(config: ProviderConfig) {
+    this.baseUrl = config.url.replace(/\/+$/, '')
+    this.apiKey = config.token
+    this.model = config.model || DEFAULT_MODELS.CUSTOM
+  }
+
+  async connect(): Promise<void> {
+    try {
+      const response = await fetch(`${this.baseUrl}/v1/models`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      })
+
+      if (!response.ok && response.status !== 401) {
+        throw new Error(`API returned status ${response.status}`)
+      }
+
+      this.connected = true
+      this.notifyConnectionState(true, false)
+    } catch {
+      this.connected = false
+      this.notifyConnectionState(false, false)
+      throw new Error('Cannot connect to Custom API. Check your API key and endpoint.')
+    }
+  }
+
+  disconnect(): void {
+    if (this.activeXhr) {
+      this.activeXhr.abort()
+      this.activeXhr = null
+    }
+    this.connected = false
+    this.notifyConnectionState(false, false)
+  }
+
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  onConnectionStateChange(
+    listener: (connected: boolean, reconnecting: boolean) => void,
+  ): () => void {
+    this.connectionListeners.push(listener)
+    return () => {
+      this.connectionListeners = this.connectionListeners.filter((l) => l !== listener)
+    }
+  }
+
+  private notifyConnectionState(connected: boolean, reconnecting: boolean) {
+    this.connectionListeners.forEach((l) => l(connected, reconnecting))
+  }
+
+  private getSessionMessages(sessionKey: string): CustomMessage[] {
+    if (!this.sessions.has(sessionKey)) {
+      this.sessions.set(sessionKey, [])
+    }
+    return this.sessions.get(sessionKey)!
+  }
+
+  async sendMessage(
+    params: SendMessageParams,
+    onEvent: (event: ChatProviderEvent) => void,
+  ): Promise<void> {
+    const messages = this.getSessionMessages(params.sessionKey)
+
+    // Build the user message content
+    const contentParts: CustomContentPart[] = []
+
+    if (params.message) {
+      contentParts.push({ type: 'text', text: params.message })
+    }
+
+    // Add image attachments if present
+    if (params.attachments?.length) {
+      for (const attachment of params.attachments) {
+        if (attachment.type === 'image' && attachment.data) {
+          const mimeType = attachment.mimeType || 'image/png'
+          contentParts.push({
+            type: 'image_url',
+            image_url: {
+              url: `data:${mimeType};base64,${attachment.data}`,
+            },
+          })
+        }
+      }
+    }
+
+    const userMsg: CustomMessage = {
+      role: 'user',
+      content:
+        contentParts.length === 1 && contentParts[0].type === 'text'
+          ? contentParts[0].text
+          : contentParts,
+    }
+
+    messages.push(userMsg)
+
+    onEvent({ type: 'lifecycle', phase: 'start' })
+
+    // Use XMLHttpRequest for streaming — React Native's fetch does not
+    // support response.body ReadableStream, so XHR with onprogress is
+    // the reliable way to receive incremental SSE data.
+    return new Promise<void>((resolve, reject) => {
+      const xhr = new XMLHttpRequest()
+      this.activeXhr = xhr
+
+      let fullResponse = ''
+      let lastIndex = 0
+
+      xhr.open('POST', `${this.baseUrl}/v1/chat/completions`)
+      xhr.setRequestHeader('Content-Type', 'application/json')
+      xhr.setRequestHeader('Authorization', `Bearer ${this.apiKey}`)
+
+      xhr.onprogress = () => {
+        const newData = xhr.responseText.substring(lastIndex)
+        lastIndex = xhr.responseText.length
+
+        const lines = newData.split('\n')
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            const data = line.slice(6).trim()
+            if (data === '[DONE]') continue
+
+            try {
+              const chunk: CustomStreamChunk = JSON.parse(data)
+
+              if (chunk.error) {
+                reject(new Error(chunk.error.message || 'Stream error'))
+                xhr.abort()
+                return
+              }
+
+              const delta = chunk.choices?.[0]?.delta?.content
+              if (delta) {
+                fullResponse += delta
+                onEvent({ type: 'delta', delta })
+              }
+            } catch {
+              // Ignore JSON parse errors from partial chunks
+            }
+          }
+        }
+      }
+
+      xhr.onload = () => {
+        this.activeXhr = null
+        if (xhr.status >= 200 && xhr.status < 300) {
+          if (fullResponse) {
+            messages.push({ role: 'assistant', content: fullResponse })
+          }
+          onEvent({ type: 'lifecycle', phase: 'end' })
+          resolve()
+        } else {
+          onEvent({ type: 'lifecycle', phase: 'end' })
+          reject(new Error(`API error: ${xhr.status} - ${xhr.responseText}`))
+        }
+      }
+
+      xhr.onerror = () => {
+        this.activeXhr = null
+        onEvent({ type: 'lifecycle', phase: 'end' })
+        reject(new Error('Network error'))
+      }
+
+      xhr.onabort = () => {
+        this.activeXhr = null
+        onEvent({ type: 'lifecycle', phase: 'end' })
+        resolve()
+      }
+
+      xhr.send(
+        JSON.stringify({
+          model: this.model,
+          max_tokens: API_CONFIG.CUSTOM_MAX_TOKENS,
+          messages: messages.map(this.formatMessageForApi),
+          stream: true,
+        }),
+      )
+    })
+  }
+
+  private formatMessageForApi(msg: CustomMessage): { role: string; content: unknown } {
+    return {
+      role: msg.role,
+      content: msg.content,
+    }
+  }
+
+  async getChatHistory(sessionKey: string, limit?: number): Promise<ChatHistoryResponse> {
+    const messages = this.getSessionMessages(sessionKey)
+    const sliced = limit ? messages.slice(-limit) : messages
+
+    const historyMessages: ChatHistoryMessage[] = sliced
+      .filter(
+        (m): m is CustomMessage & { role: 'user' | 'assistant' } =>
+          m.role === 'user' || m.role === 'assistant',
+      )
+      .map((m, i) => ({
+        role: m.role,
+        content: [{ type: 'text', text: this.extractTextContent(m.content) }],
+        timestamp: Date.now() - (sliced.length - i) * 1000,
+      }))
+
+    return { messages: historyMessages }
+  }
+
+  private extractTextContent(content: string | CustomContentPart[]): string {
+    if (typeof content === 'string') {
+      return content
+    }
+    const textParts = content.filter((p): p is CustomTextPart => p.type === 'text' && !!p.text)
+    return textParts.map((p) => p.text).join('\n')
+  }
+
+  async resetSession(sessionKey: string): Promise<void> {
+    this.sessions.delete(sessionKey)
+  }
+
+  async listSessions(): Promise<unknown> {
+    return {
+      sessions: Array.from(this.sessions.keys()).map((key) => ({
+        key,
+        messageCount: this.sessions.get(key)?.length ?? 0,
+      })),
+    }
+  }
+
+  async getHealth(): Promise<HealthStatus> {
+    try {
+      const response = await fetch(`${this.baseUrl}/v1/models`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      })
+
+      if (response.ok) {
+        return { status: 'healthy' }
+      }
+      return { status: 'degraded' }
+    } catch {
+      return { status: 'unhealthy' }
+    }
+  }
+}

--- a/src/services/providers/createProvider.ts
+++ b/src/services/providers/createProvider.ts
@@ -1,5 +1,6 @@
 import { AppleChatProvider } from '../apple-intelligence/AppleChatProvider'
 import { ClaudeChatProvider } from '../claude/ClaudeChatProvider'
+import { CustomChatProvider } from '../custom/CustomChatProvider'
 import { EchoChatProvider } from '../echo/EchoChatProvider'
 import { EmergentChatProvider } from '../emergent/EmergentChatProvider'
 import { GeminiChatProvider } from '../gemini/GeminiChatProvider'
@@ -56,6 +57,9 @@ export function createChatProvider(config: ProviderConfig): ChatProvider {
       break
     case 'kimi':
       inner = new KimiChatProvider(config)
+      break
+    case 'custom':
+      inner = new CustomChatProvider(config)
       break
     default:
       throw new Error(`Unknown provider type: ${(config as ProviderConfig).type}`)

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -13,6 +13,7 @@ export type ProviderType =
   | 'gemini'
   | 'emergent'
   | 'kimi'
+  | 'custom'
 
 export interface ProviderConfig {
   type: ProviderType


### PR DESCRIPTION
Introduces a new "Custom (OpenAI-compatible)" provider type that allows
users to connect to any OpenAI-compatible API by specifying their own
base URL, API key, and model. This is useful for self-hosted or
third-party services that expose an OpenAI-compatible endpoint.

https://claude.ai/code/session_01L5Zwoj6JPPTEuukYMQtqLG