### PR TITLE
Remove default theme and use Lumiere as principal theme

### DIFF
--- a/app/__tests__/app-startup.test.tsx
+++ b/app/__tests__/app-startup.test.tsx
@@ -109,7 +109,7 @@ jest.mock('../../src/theme', () => {
       themeMode: 'light' as const,
       setThemeMode: jest.fn(),
       toggleTheme: jest.fn(),
-      colorTheme: 'default' as const,
+      colorTheme: 'lumiere' as const,
       setColorTheme: jest.fn(),
     }),
   }

--- a/app/colors.tsx
+++ b/app/colors.tsx
@@ -7,7 +7,6 @@ import { useTheme } from '../src/theme'
 import { ColorThemeKey, colorThemes } from '../src/theme/colors'
 
 const COLOR_THEME_KEYS: ColorThemeKey[] = [
-  'default',
   'lumiere',
   'pink',
   'green',

--- a/src/components/ui/GradientBubble.tsx
+++ b/src/components/ui/GradientBubble.tsx
@@ -65,7 +65,11 @@ export function GradientBubble({
 
   const isUser = variant === 'user'
 
-  const userGradientColors = ['#22D3EE', '#06B6D4', '#0891B2'] as const
+  const userGradientColors = [
+    theme.colors.primary,
+    theme.colors.primaryDark,
+    theme.colors.primaryDark,
+  ] as const
   const agentGradientColors = [theme.colors.surface, theme.colors.surfaceVariant] as const
 
   const styles = StyleSheet.create({

--- a/src/theme/__tests__/colors.test.ts
+++ b/src/theme/__tests__/colors.test.ts
@@ -2,7 +2,7 @@ import { colorThemes, darkColors, lightColors } from '../colors'
 
 describe('lightColors', () => {
   it('has the expected primary color', () => {
-    expect(lightColors.primary).toBe('#FF6B47')
+    expect(lightColors.primary).toBe('#22D3EE')
   })
 
   it('contains all required text color keys', () => {
@@ -43,17 +43,7 @@ describe('darkColors', () => {
 })
 
 describe('colorThemes', () => {
-  const themeKeys = [
-    'default',
-    'pink',
-    'green',
-    'red',
-    'blue',
-    'purple',
-    'orange',
-    'glass',
-    'lumiere',
-  ]
+  const themeKeys = ['pink', 'green', 'red', 'blue', 'purple', 'orange', 'glass', 'lumiere']
 
   it('has all expected theme keys', () => {
     expect(Object.keys(colorThemes)).toEqual(expect.arrayContaining(themeKeys))

--- a/src/theme/__tests__/themes.test.ts
+++ b/src/theme/__tests__/themes.test.ts
@@ -20,12 +20,7 @@ describe('darkTheme', () => {
 })
 
 describe('applyColorTheme', () => {
-  it('returns base theme unchanged for default color theme', () => {
-    const result = applyColorTheme(lightTheme, 'default')
-    expect(result).toBe(lightTheme)
-  })
-
-  it('overrides primary colors for non-default themes', () => {
+  it('overrides primary colors for color themes', () => {
     const result = applyColorTheme(lightTheme, 'blue')
     expect(result.colors.primary).toBe('#2563EB')
     expect(result.colors.primaryLight).toBe('#60A5FA')

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,24 +1,24 @@
 export const lightColors = {
-  primary: '#FF6B47',
-  primaryLight: '#FF8A6B',
-  primaryDark: '#E85A3C',
+  primary: '#22D3EE',
+  primaryLight: '#67E8F9',
+  primaryDark: '#06B6D4',
 
-  background: '#F2EFE9',
-  surface: '#E8E5DD',
-  surfaceVariant: '#DDD9D0',
+  background: '#F0F4F8',
+  surface: '#FFFFFF',
+  surfaceVariant: '#E8EDF4',
 
   text: {
-    primary: '#3C3C3C',
-    secondary: '#9B9B9B',
-    tertiary: '#B8B8B8',
+    primary: '#1A2A3A',
+    secondary: '#64748B',
+    tertiary: '#94A3B8',
     inverse: '#FFFFFF',
   },
 
   message: {
-    user: '#FF6B47',
-    agent: '#DDD9D0',
-    userText: '#FFFFFF',
-    agentText: '#3C3C3C',
+    user: '#22D3EE',
+    agent: '#E8EDF4',
+    userText: '#050A18',
+    agentText: '#1A2A3A',
   },
 
   status: {
@@ -28,9 +28,9 @@ export const lightColors = {
     info: '#5AC8FA',
   },
 
-  border: '#DDD9D0',
-  divider: '#C7C7C7',
-  shadow: 'rgba(0, 0, 0, 0.08)',
+  border: '#CBD5E1',
+  divider: '#E2E8F0',
+  shadow: 'rgba(0, 40, 80, 0.08)',
 }
 
 export const darkColors = {
@@ -112,7 +112,7 @@ export interface ColorThemePalette {
 }
 
 export type ColorThemeKey =
-  | 'default'
+  | 'lumiere'
   | 'pink'
   | 'green'
   | 'red'
@@ -120,26 +120,8 @@ export type ColorThemeKey =
   | 'purple'
   | 'orange'
   | 'glass'
-  | 'lumiere'
 
 export const colorThemes: Record<ColorThemeKey, ColorThemePalette> = {
-  default: {
-    name: 'Default',
-    light: {
-      primary: '#FF6B47',
-      primaryLight: '#FF8A6B',
-      primaryDark: '#E85A3C',
-      messageUser: '#FF6B47',
-      messageUserText: '#FFFFFF',
-    },
-    dark: {
-      primary: '#FFD60A',
-      primaryLight: '#FFE34D',
-      primaryDark: '#FFCC00',
-      messageUser: '#FFD60A',
-      messageUserText: '#000000',
-    },
-  },
   pink: {
     name: 'Pink',
     light: {

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -33,10 +33,6 @@ export type ThemeMode = 'light' | 'dark' | 'system'
  * Themes like "glass" also override backgrounds, surfaces, text, and borders.
  */
 export function applyColorTheme(baseTheme: Theme, colorThemeKey: ColorThemeKey): Theme {
-  if (colorThemeKey === 'default') {
-    return baseTheme
-  }
-
   const palette = colorThemes[colorThemeKey]
   const variant = baseTheme.isDark ? palette.dark : palette.light
 


### PR DESCRIPTION
- Update base light colors to use Lumiere palette instead of coral/orange
- Remove 'default' color theme from ColorThemeKey and colorThemes
- Use theme tint colors (primary/primaryDark) in GradientBubble instead of
  hardcoded cyan values, so bubble gradients follow the selected color theme
- Update theme picker, tests, and applyColorTheme accordingly

https://claude.ai/code/session_01ScdzMCsN26i1Rw2meVMBuY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced 'lumiere' color theme to replace the default theme option.
  * User message bubbles now dynamically respond to app theme color changes.

* **Style**
  * Updated light mode color palette including primary colors, backgrounds, surfaces, text, messages, and border styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->